### PR TITLE
Delete copy constructors of lib classes

### DIFF
--- a/lib/include/AssistiveRehab/skeleton.h
+++ b/lib/include/AssistiveRehab/skeleton.h
@@ -66,6 +66,8 @@ public:
     KeyPoint();
     KeyPoint(const std::string &tag_, const yarp::sig::Vector &point_=yarp::sig::Vector(3,0.0),
              const bool updated_=false);
+    KeyPoint(const KeyPoint&) = delete;
+    KeyPoint& operator=(const KeyPoint&) = delete;
     virtual ~KeyPoint() { }
 
     bool isUpdated() const { return updated; }
@@ -94,7 +96,7 @@ protected:
     yarp::sig::Vector sagittal;
     yarp::sig::Vector transverse;
 
-    yarp::os::Property helper_toproperty(KeyPoint* k) const;
+    yarp::os::Property helper_toproperty(KeyPoint *k) const;
     void helper_fromproperty(yarp::os::Bottle *prop, KeyPoint *parent);
     void helper_updatefromproperty(yarp::os::Bottle *prop);
     void helper_normalize(KeyPoint* k, const std::vector<yarp::sig::Vector> &helperpoints);
@@ -102,6 +104,8 @@ protected:
 
 public:
     Skeleton();
+    Skeleton(const Skeleton&) = delete;
+    Skeleton& operator=(const Skeleton&) = delete;
     virtual ~Skeleton();
 
     const std::string& getType() const { return type; }

--- a/lib/src/skeleton.cpp
+++ b/lib/src/skeleton.cpp
@@ -92,7 +92,7 @@ Skeleton::~Skeleton()
         delete k;
 }
 
-Property Skeleton::helper_toproperty(KeyPoint* k) const
+Property Skeleton::helper_toproperty(KeyPoint *k) const
 {
     Property prop;
     if (k!=nullptr)

--- a/modules/motionAnalyzer/src/Processor.cpp
+++ b/modules/motionAnalyzer/src/Processor.cpp
@@ -53,7 +53,7 @@ bool Processor::isStatic(const KeyPoint& keypoint)
 
 void Processor::update(const SkeletonWaist &curr_skeleton_)
 {
-    curr_skeleton = curr_skeleton_;
+    curr_skeleton.update(curr_skeleton_.get_unordered());
 }
 
 bool Processor::isDeviatingFromIntialPose()
@@ -167,7 +167,7 @@ Rom_Processor::Rom_Processor(const Metric *rom_)
 
 void Rom_Processor::setInitialConf(const SkeletonWaist &skeleton_init_, const map<string, pair<string, double> > &keypoints2conf_)
 {
-    skeleton_init = skeleton_init_;
+    skeleton_init.update(skeleton_init_.get_unordered());
     keypoints2conf = keypoints2conf_;
 }
 


### PR DESCRIPTION
`KeyPoint` and `Skeleton` **copy constructors** along with the corresponding **operator=()** are created by the compiler in the wrong way because I didn't specify them. I forgot to explicitly make the compiler avoid their default implementation (my bad 😞).
Done in this PR.

The reason why I would rather make them _deleted_ is that the two classes handle internally a number of lists that it would take some unwieldy job to copy out correctly.

As a result, the `motionAnalyzer` code has to be modified accordingly. I've drafted a possible solution.
@vvasco please revise.

We can discuss in person the implications/risks of using default copy constructors for complex objects.