### PR TITLE
Skeleton tracking shifted in 2D

### DIFF
--- a/modules/skeletonRetriever/app/conf/config.ini
+++ b/modules/skeletonRetriever/app/conf/config.ini
@@ -5,9 +5,9 @@ period 0.01
 keys-recognition-confidence 0.3
 keys-recognition-percentage 0.4
 keys-acceptable-misses      5
-tracking-threshold          30
+tracking-threshold          50
 time-to-live                1.0
 
 [filtering]
 filter-enable               on
-filter-order                5
+filter-order                3

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -416,10 +416,10 @@ class Retriever : public RFModule
         keys_recognition_confidence=0.3;
         keys_recognition_percentage=0.4;
         keys_acceptable_misses=5;
-        tracking_threshold=30;
+        tracking_threshold=50;
         time_to_live=1.0;
         filter_enable=true;
-        filter_order=5;
+        filter_order=3;
 
         // retrieve values from config file
         Bottle &gGeneral=rf.findGroup("general");


### PR DESCRIPTION
To make skeleton tracking more robust, we shift the scores computation in 2D rather than 3D and only by dealing with `shoulder_center` key-point.