### PR TITLE
Introduced remove-tags command in skeletonViewer

### DIFF
--- a/modules/skeletonRetriever/app/scripts/skeletonRetriever-faces.xml.template
+++ b/modules/skeletonRetriever/app/scripts/skeletonRetriever-faces.xml.template
@@ -53,19 +53,19 @@
 
     <module>
         <name>yarpview</name>
-        <parameters>--name /viewer/depth --x 10 --y 10 --p 50 --compact</parameters>
+        <parameters>--name /viewer/depth --x 10 --y 40 --p 50 --compact</parameters>
         <node>localhost</node>
     </module>
 
     <module>
         <name>yarpview</name>
-        <parameters>--name /viewer/skeleton --x 380 --y 10 --p 50 --compact</parameters>
+        <parameters>--name /viewer/skeleton --x 380 --y 40 --p 50 --compact</parameters>
         <node>localhost</node>
     </module>
 
     <module>
         <name>yarpview</name>
-        <parameters>--name /viewer/faces --x 700 --y 10 --p 50 --compact</parameters>
+        <parameters>--name /viewer/faces --x 750 --y 40 --p 50 --compact</parameters>
         <node>localhost</node>
     </module>
 

--- a/modules/skeletonRetriever/app/scripts/skeletonRetriever.xml.template
+++ b/modules/skeletonRetriever/app/scripts/skeletonRetriever.xml.template
@@ -26,13 +26,13 @@
 
     <module>
         <name>yarpview</name>
-        <parameters>--name /viewer/depth --x 10 --y 10 --p 50 --compact</parameters>
+        <parameters>--name /viewer/depth --x 10 --y 40 --p 50 --compact</parameters>
         <node>localhost</node>
     </module>
 
     <module>
         <name>yarpview</name>
-        <parameters>--name /viewer/skeleton --x 380 --y 10 --p 50 --compact</parameters>
+        <parameters>--name /viewer/skeleton --x 380 --y 40 --p 50 --compact</parameters>
         <node>localhost</node>
     </module>
 


### PR DESCRIPTION
The introduction of such a new command allows for removing stale skeletons before their timeout expires. This way, we can readily filter out glitches in the face recognition pipeline.

cc @vtikha 