### PR TITLE
Added new commands in motionAnalyzer

### DIFF
--- a/modules/motionAnalyzer/include/Manager.h
+++ b/modules/motionAnalyzer/include/Manager.h
@@ -103,6 +103,8 @@ class Manager : public RFModule,
     mat_t *matfp;
     string filename_report;
 
+    bool starting;
+
 //    Metric* metric;
 //    Processor* processor;
 
@@ -112,6 +114,9 @@ class Manager : public RFModule,
     bool loadMotionList();
 //    bool loadSequence(const string& sequencer_file);
     bool loadMetric(const string &metric_tag);
+    vector<string> listMetrics();
+    bool start();
+    bool stop();
 
     bool writeStructToMat(const string& name, const vector< vector< pair<string,Vector> > >& keypoints_skel);
     bool writeStructToMat(const string& name, const Metric& metric);

--- a/modules/motionAnalyzer/src/idl.thrift
+++ b/modules/motionAnalyzer/src/idl.thrift
@@ -20,16 +20,30 @@ service motionAnalyzer_IDL
    bool loadMotionList();
 
    /**
-   * Load sequence from file.
-   * @return true/false on success/failure.
-   */
-   bool loadSequence(1:string sequencer_file);
-
-   /**
    * Load metric to analyze.
    * @param metric_tag name of the metric to analyze
    * @return true/false on success/failure.
    */
    bool loadMetric(1:string metric_tag);
+
+   /**
+   * List available metrics.
+   * @return the list of the available metrics as defined in the motion-repertoire.
+   */
+   list<string> listMetrics();
+
+   /**
+   * Start processing.
+   * @return true/false on success/failure.
+   */
+   bool start();
+
+   /**
+   * Stop processing.
+   * @return true/false on success/failure.
+   */
+   bool stop();
+
+
 
 }


### PR DESCRIPTION
The `motionAnalyzer` module opens a rpc port, called `/motionAnalyzer/cmd`, through which it accepts commands. This PR introduces the following commands:
- `start`: starts processing
- `stop`: stops processing
- `listMetrics`: lists all the available metrics as defined in the `motion-repertoire.ini` file

Once the `motionAnalyzer` application is running and the connections are active, the `motionAnalyzer` module waits for a metric to be defined through the command `loadMetric`. 
The command `stop` stops the processing and resets the current metric. Therefore a new metric has to be loaded for a new processing.

Typical usage:
1.  Run `motionAnalyzer` application and connect
2. Open a terminal and type `yarp rpc /motionAnalyzer/cmd`. Then type:
- `loadMetric ROM_0`
- `start`
- `stop`
