### PR TITLE
yarpOpenPose propagates depth

### DIFF
--- a/app/scripts/AssistiveRehab-faces.xml.template
+++ b/app/scripts/AssistiveRehab-faces.xml.template
@@ -146,19 +146,19 @@
     <connection>
         <from>/faceExpressionImage/image:o</from> 
         <to>/robot/faceDisplay/image:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/iSpeak/speech-dev/rpc</from>
         <to>/r1/speech:rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/iSpeak/r1:rpc</from>
         <to>/faceExpressionImage/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -169,6 +169,12 @@
 
     <connection>
         <from>/depthCamera/depthImage:o</from>
+        <to>/yarpOpenPose/float:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/float:o</from>
         <to>/skeletonRetriever/depth:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
@@ -176,7 +182,7 @@
     <connection>
         <from>/skeletonRetriever/cam:rpc</from>
         <to>/depthCamera/rpc:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -188,25 +194,25 @@
     <connection>
         <from>/caffeCoder/code:o</from>
         <to>/himrepClassifier/features:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/himrepClassifier/features:o</from>
         <to>/linearClassifier/features:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/linearClassifier/scores:o</from>
         <to>/himrepClassifier/scores:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/himrepClassifier/classify:rpc</from>
         <to>/linearClassifier/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -218,7 +224,7 @@
     <connection>
         <from>/yarpOpenPose/target:o</from>
         <to>/human-structure/skeleton:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -236,19 +242,19 @@
     <connection>
         <from>/human-structure/target:o</from>
         <to>/recognition-manager/target:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/human-structure/blobs:o</from>
         <to>/recognition-manager/blobs:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/recognition-manager/classify:rpc</from>
         <to>/himrepClassifier/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -260,13 +266,13 @@
     <connection>
         <from>/recognition-manager/target:o</from>
         <to>/skeletonRetriever/skeletons:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonRetriever/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -278,7 +284,7 @@
     <connection>
         <from>/attentionManager/gaze/cmd:rpc</from>
         <to>/cer_gaze-controller/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -290,25 +296,25 @@
     <connection>
         <from>/motionAnalyzer/opc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/motionAnalyzer/scaler:cmd</from>
         <to>/skeletonScaler/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonPlayer/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonScaler/opc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -332,48 +338,48 @@
     <connection>
         <from>/skeletonRetriever/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonPlayer/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonScaler/player:rpc</from>
         <to>/skeletonPlayer/cmd:rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonScaler/viewer:rpc</from>
         <to>/skeletonViewer:rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/interactionManager/attention:rpc</from>
         <to>/attentionManager/cmd:rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/interactionManager/analyzer:rpc</from>
         <to>/motionAnalyzer/cmd</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/interactionManager/speech:o</from>
         <to>/iSpeak</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/interactionManager/speech:rpc</from>
         <to>/iSpeak/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 </application>

--- a/app/scripts/AssistiveRehab.xml.template
+++ b/app/scripts/AssistiveRehab.xml.template
@@ -113,19 +113,19 @@
     <connection>
         <from>/faceExpressionImage/image:o</from> 
         <to>/robot/faceDisplay/image:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/iSpeak/speech-dev/rpc</from>
         <to>/r1/speech:rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/iSpeak/r1:rpc</from>
         <to>/faceExpressionImage/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -136,6 +136,12 @@
 
     <connection>
         <from>/depthCamera/depthImage:o</from>
+        <to>/yarpOpenPose/float:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/float:o</from>
         <to>/skeletonRetriever/depth:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
@@ -143,19 +149,19 @@
     <connection>
         <from>/skeletonRetriever/cam:rpc</from>
         <to>/depthCamera/rpc:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/yarpOpenPose/target:o</from>
         <to>/skeletonRetriever/skeletons:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonRetriever/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -167,7 +173,7 @@
     <connection>
         <from>/attentionManager/gaze/cmd:rpc</from>
         <to>/cer_gaze-controller/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -179,25 +185,25 @@
     <connection>
         <from>/motionAnalyzer/opc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/motionAnalyzer/scaler:cmd</from>
         <to>/skeletonScaler/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonPlayer/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonScaler/opc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -215,48 +221,48 @@
     <connection>
         <from>/skeletonRetriever/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonPlayer/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonScaler/player:rpc</from>
         <to>/skeletonPlayer/cmd:rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonScaler/viewer:rpc</from>
         <to>/skeletonViewer:rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/interactionManager/attention:rpc</from>
         <to>/attentionManager/cmd:rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/interactionManager/analyzer:rpc</from>
         <to>/motionAnalyzer/cmd</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/interactionManager/speech:o</from>
         <to>/iSpeak</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/interactionManager/speech:rpc</from>
         <to>/iSpeak/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 </application>

--- a/app/scripts/skeletonDumper-faces.xml.template
+++ b/app/scripts/skeletonDumper-faces.xml.template
@@ -30,11 +30,11 @@
     <connection>
         <from>/recognition-manager/target:o</from>
         <to>/skeletonDumper/skeletons-data</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
-        <from>/depthCamera/depthImage:o</from>
+        <from>/yarpOpenPose/float:o</from>
         <to>/skeletonDumper/depth</to>
         <protocol>fast_tcp</protocol>
     </connection>

--- a/app/scripts/skeletonDumper.xml.template
+++ b/app/scripts/skeletonDumper.xml.template
@@ -25,11 +25,11 @@
     <connection>
         <from>/yarpOpenPose/target:o</from>
         <to>/skeletonDumper/skeletons-data</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
-        <from>/depthCamera/depthImage:o</from>
+        <from>/yarpOpenPose/float:o</from>
         <to>/skeletonDumper/depth</to>
         <protocol>fast_tcp</protocol>
     </connection>

--- a/modules/attentionManager/app/scripts/attentionManager-faces.xml.template
+++ b/modules/attentionManager/app/scripts/attentionManager-faces.xml.template
@@ -95,6 +95,12 @@
 
     <connection>
         <from>/depthCamera/depthImage:o</from>
+        <to>/yarpOpenPose/float:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/float:o</from>
         <to>/skeletonRetriever/depth:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
@@ -102,7 +108,7 @@
     <connection>
         <from>/skeletonRetriever/cam:rpc</from>
         <to>/depthCamera/rpc:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -114,25 +120,25 @@
     <connection>
         <from>/caffeCoder/code:o</from>
         <to>/himrepClassifier/features:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/himrepClassifier/features:o</from>
         <to>/linearClassifier/features:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/linearClassifier/scores:o</from>
         <to>/himrepClassifier/scores:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/himrepClassifier/classify:rpc</from>
         <to>/linearClassifier/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -144,7 +150,7 @@
     <connection>
         <from>/yarpOpenPose/target:o</from>
         <to>/human-structure/skeleton:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -162,19 +168,19 @@
     <connection>
         <from>/human-structure/target:o</from>
         <to>/recognition-manager/target:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/human-structure/blobs:o</from>
         <to>/recognition-manager/blobs:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/recognition-manager/classify:rpc</from>
         <to>/himrepClassifier/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -186,13 +192,13 @@
     <connection>
         <from>/recognition-manager/target:o</from>
         <to>/skeletonRetriever/skeletons:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonRetriever/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -204,7 +210,7 @@
     <connection>
         <from>/attentionManager/gaze/cmd:rpc</from>
         <to>/cer_gaze-controller/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -234,6 +240,6 @@
     <connection>
         <from>/skeletonRetriever/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 </application>

--- a/modules/attentionManager/app/scripts/attentionManager.xml.template
+++ b/modules/attentionManager/app/scripts/attentionManager.xml.template
@@ -62,6 +62,12 @@
 
     <connection>
         <from>/depthCamera/depthImage:o</from>
+        <to>/yarpOpenPose/float:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/float:o</from>
         <to>/skeletonRetriever/depth:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
@@ -69,19 +75,19 @@
     <connection>
         <from>/skeletonRetriever/cam:rpc</from>
         <to>/depthCamera/rpc:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/yarpOpenPose/target:o</from>
         <to>/skeletonRetriever/skeletons:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonRetriever/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -93,7 +99,7 @@
     <connection>
         <from>/attentionManager/gaze/cmd:rpc</from>
         <to>/cer_gaze-controller/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -117,6 +123,6 @@
     <connection>
         <from>/skeletonRetriever/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 </application>

--- a/modules/motionAnalyzer/app/scripts/motionAnalyzer.xml.template
+++ b/modules/motionAnalyzer/app/scripts/motionAnalyzer.xml.template
@@ -62,6 +62,12 @@
 
     <connection>
         <from>/depthCamera/depthImage:o</from>
+        <to>/yarpOpenPose/float:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/float:o</from>
         <to>/skeletonRetriever/depth:i</to>
         <protocol>fast_tcp</protocol>
     </connection>

--- a/modules/skeletonPlayer/app/scripts/skeletonPlayer.xml.template
+++ b/modules/skeletonPlayer/app/scripts/skeletonPlayer.xml.template
@@ -22,12 +22,12 @@
     <connection>
         <from>/skeletonPlayer/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonPlayer/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 </application>

--- a/modules/skeletonRetriever/app/scripts/skeletonRetriever-faces.xml.template
+++ b/modules/skeletonRetriever/app/scripts/skeletonRetriever-faces.xml.template
@@ -83,6 +83,12 @@
 
     <connection>
         <from>/depthCamera/depthImage:o</from>
+        <to>/yarpOpenPose/float:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/float:o</from>
         <to>/skeletonRetriever/depth:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
@@ -90,7 +96,7 @@
     <connection>
         <from>/skeletonRetriever/cam:rpc</from>
         <to>/depthCamera/rpc:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -102,25 +108,25 @@
     <connection>
         <from>/caffeCoder/code:o</from>
         <to>/himrepClassifier/features:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/himrepClassifier/features:o</from>
         <to>/linearClassifier/features:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/linearClassifier/scores:o</from>
         <to>/himrepClassifier/scores:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/himrepClassifier/classify:rpc</from>
         <to>/linearClassifier/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -132,7 +138,7 @@
     <connection>
         <from>/yarpOpenPose/target:o</from>
         <to>/human-structure/skeleton:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -150,19 +156,19 @@
     <connection>
         <from>/human-structure/target:o</from>
         <to>/recognition-manager/target:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/human-structure/blobs:o</from>
         <to>/recognition-manager/blobs:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/recognition-manager/classify:rpc</from>
         <to>/himrepClassifier/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -174,13 +180,13 @@
     <connection>
         <from>/recognition-manager/target:o</from>
         <to>/skeletonRetriever/skeletons:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonRetriever/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -204,6 +210,6 @@
     <connection>
         <from>/skeletonRetriever/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 </application>

--- a/modules/skeletonRetriever/app/scripts/skeletonRetriever.xml.template
+++ b/modules/skeletonRetriever/app/scripts/skeletonRetriever.xml.template
@@ -50,26 +50,33 @@
 
     <connection>
         <from>/depthCamera/depthImage:o</from>
+        <to>/yarpOpenPose/float:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/float:o</from>
         <to>/skeletonRetriever/depth:i</to>
         <protocol>fast_tcp</protocol>
+    </connection>
     </connection>
 
     <connection>
         <from>/skeletonRetriever/cam:rpc</from>
         <to>/depthCamera/rpc:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/yarpOpenPose/target:o</from>
         <to>/skeletonRetriever/skeletons:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonRetriever/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -87,6 +94,6 @@
     <connection>
         <from>/skeletonRetriever/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 </application>

--- a/modules/skeletonScaler/app/scripts/skeletonScaler.xml.template
+++ b/modules/skeletonScaler/app/scripts/skeletonScaler.xml.template
@@ -58,78 +58,84 @@
     <connection>
         <from>/depthCamera/rgbImage:o</from>
         <to>/yarpOpenPose/image:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/depthCamera/depthImage:o</from>
+        <to>/yarpOpenPose/float:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/float:o</from>
         <to>/skeletonRetriever/depth:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonRetriever/cam:rpc</from>
         <to>/depthCamera/rpc:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/yarpOpenPose/target:o</from>
         <to>/skeletonRetriever/skeletons:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonRetriever/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/depthCamera/depthImage:o</from>
         <to>/viewer/depth</to>
-        <protocol>tcp+recv.portmonitor+type.dll+file.depthimage</protocol>
+        <protocol>fast_tcp+recv.portmonitor+type.dll+file.depthimage</protocol>
     </connection>
 
     <connection>
         <from>/yarpOpenPose/image:o</from>
         <to>/viewer/skeleton</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonRetriever/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonPlayer/opc:rpc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonPlayer/viewer:o</from>
         <to>/skeletonViewer:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonScaler/opc</from>
         <to>/opc/rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonScaler/player:rpc</from>
         <to>/skeletonPlayer/cmd:rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/skeletonScaler/viewer:rpc</from>
         <to>/skeletonViewer:rpc</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 </application>


### PR DESCRIPTION
Upon https://github.com/robotology/human-sensing/commit/43fc809b2813c5eb3f80d98f6a94905653cb7861 @vtikha made, `yarpOpenPose` now propagates depth images in sync with the output of skeleton detection.

Therefore, this PR updates all the xml applications to correctly deliver depth downstream.

Once merged, @vvasco could you please do the test in #83 again to verify the improvement?

Hopefully, we'll fix #77 🤞  