### PR TITLE
Updated interactionManager for the new demo

### DIFF
--- a/modules/interactionManager/src/main.cpp
+++ b/modules/interactionManager/src/main.cpp
@@ -88,8 +88,6 @@ class Interaction : public RFModule, public interactionManager_IDL
         {
             if (rep.get(0).asVocab()==ok)
             {
-//                if (state==State::assess)
-//                {
                 if (state==State::wait)
                 {
                     Bottle cmd,rep;
@@ -354,8 +352,6 @@ class Interaction : public RFModule, public interactionManager_IDL
         {
             if (follow_tag!=tag)
             {
-//                if (state==State::assess)
-//                {
                 if (state==State::wait)
                 {
                     Bottle cmd,rep;
@@ -482,8 +478,6 @@ class Interaction : public RFModule, public interactionManager_IDL
                                             history[tag].insert(metric);
 
                                             state=State::wait;
-//                                            state=State::assess;
-//                                            assess_values.clear();
                                             t0=Time::now();
                                             t1=t0;
                                         }
@@ -494,11 +488,6 @@ class Interaction : public RFModule, public interactionManager_IDL
                     }
                 }
             }
-//            if (state!=State::assess)
-//            {
-//                speak("ouch",true);
-//                disengage();
-//            }
             if (state!=State::wait)
             {
                 speak("ouch",true);


### PR DESCRIPTION
The `interactionManager` is no longer in charge of the evaluation of the quality of the movement. 
When the person is engaged and the exercise starts, it waits until the exercise is over.
Meanwhile, the `feedbackSynthetizer` provides the verbal feedback during the exercise.