### PR TITLE
recognition-manager updated to use YARP >= 3.0

### DIFF
--- a/modules/recognition-manager/include/queryThread.h
+++ b/modules/recognition-manager/include/queryThread.h
@@ -22,7 +22,7 @@
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/RpcClient.h>
 #include <yarp/os/PortReport.h>
@@ -49,12 +49,12 @@
 #include <list>
 
 
-class QueryThread: public yarp::os::RateThread
+class QueryThread: public yarp::os::PeriodicThread
 {
 
 private:
 
-	yarp::os::ResourceFinder                    &rf;
+    yarp::os::ResourceFinder                    &rf;
     yarp::os::Semaphore                         mutex;
     bool                                        verbose;
     
@@ -75,7 +75,7 @@ private:
 
 public:
 
-    QueryThread(yarp::os::ResourceFinder &_rf) : yarp::os::RateThread(5), rf(_rf) { }
+    QueryThread(yarp::os::ResourceFinder &_rf) : yarp::os::PeriodicThread(0.005), rf(_rf) { }
     
     bool set_skip_frames(int skip_frames);
     
@@ -87,11 +87,11 @@ public:
 
     virtual bool threadInit();
 
-	virtual void run();
+    virtual void run();
 
     virtual void interrupt();
 
-	virtual bool releaseThread();
+    virtual bool releaseThread();
 
 };
 

--- a/modules/recognition-manager/src/main.cpp
+++ b/modules/recognition-manager/src/main.cpp
@@ -15,6 +15,7 @@
  * Public License for more details
  */
 
+#include <yarp/os/Vocab.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/RFModule.h>
@@ -37,8 +38,8 @@
 #include <queryThread.h>
 #include "recognition_IDL.h"
 
-#define                 ACK                 VOCAB3('a','c','k')
-#define                 NACK                VOCAB4('n','a','c','k')
+#define                 ACK                 yarp::os::createVocab('a','c','k')
+#define                 NACK                yarp::os::createVocab('n','a','c','k')
 
 /********************************************************/
 class Module : public yarp::os::RFModule, public recognition_IDL
@@ -799,7 +800,7 @@ public:
             port_rpc_classifier.write(cmdObjClass,objClassList);
             if (objClassList.get(0).asString()=="ack")
                 if (yarp::os::Bottle *objList=objClassList.get(1).asList())
-                    classes = objList->size();
+                    classes = (int)objList->size();
 
             //yInfo()<< "number of classes " << classes;
 

--- a/modules/recognition-manager/src/queryThread.cpp
+++ b/modules/recognition-manager/src/queryThread.cpp
@@ -262,5 +262,5 @@ bool QueryThread::releaseThread()
     port_in_img.close();
     port_out_show.close();
     port_out_crop.close();
-	return true;
+    return true;
 }


### PR DESCRIPTION
@vtikha please have a look at these tiny modifications done to make `recognition-manager` compatible with YARP >= 3.0.

Modifications are concerned with:
- the use of `yarp::os::createVocab()` in place of old defines;
- the use of `yarp::os::PeriodicThread` in place of `yarp::os::RateThread`.