### PR TITLE
Engage user only in front of the robot

### DIFF
--- a/modules/attentionManager/src/idl.thrift
+++ b/modules/attentionManager/src/idl.thrift
@@ -11,6 +11,34 @@
  */
 
 /**
+* FollowedSkeletonInfo
+*
+* IDL structure to send info on followed skeleton.
+*/
+struct FollowedSkeletonInfo
+{
+   /**
+   * the tag of the followed skeleton; empty otherwise.
+   */
+   1:string tag;
+
+   /**
+   * the x-coordinate.
+   */
+   2:double x;
+
+   /**
+   * the y-coordinate.
+   */
+   3:double y;
+
+   /**
+   * the z-coordinate.
+   */
+   4:double z;
+}
+
+/**
  * attentionManager_IDL
  *
  * IDL Interface to Attention Manager services.
@@ -39,9 +67,9 @@ service attentionManager_IDL
 
    /**
     * Check if the robot is following a skeleton.
-    * @return the tag of the followed skeleton; empty otherwise.
+    * @return info on the followed skeleton in \ref FollowedSkeletonInfo format.
     */
-   string is_following();
+   FollowedSkeletonInfo is_following();
 
    /**
     * Check if any skeleton is with one hand raised.

--- a/modules/interactionManager/app/conf/config-en.ini
+++ b/modules/interactionManager/app/conf/config-en.ini
@@ -1,4 +1,6 @@
-period       0.1
-speak-file   speak-en.ini
-move-file    run-movements.sh
+period              0.1
+speak-file          speak-en.ini
+move-file           run-movements.sh
+engage-distance     (2.0 4.0)
+engage-azimuth      (-15.0 15.0)
 

--- a/modules/interactionManager/app/conf/config-it.ini
+++ b/modules/interactionManager/app/conf/config-it.ini
@@ -1,4 +1,6 @@
-period       0.1
-speak-file   speak-it.ini
-move-file    run-movements.sh
+period              0.1
+speak-file          speak-it.ini
+move-file           run-movements.sh
+engage-distance     (2.0 4.0)
+engage-azimuth      (-15.0 15.0)
 


### PR DESCRIPTION
This PR forces the engagement of the user only when he/she is in front of the robot.

Note how "being in front of the robot" is determined by means of a couple of parameters specified for the `interactionManager` module.

Further, the proposed changes are to be merged into `feat-movements` branch.

cc @vvasco 