### PR TITLE
[interactionManager] stopping motionAnalyzer if something goes wrong

### DIFF
--- a/modules/interactionManager/src/main.cpp
+++ b/modules/interactionManager/src/main.cpp
@@ -628,6 +628,10 @@ class Interaction : public RFModule, public interactionManager_IDL
             }
             if (state!=State::move)
             {
+                Bottle cmd,rep;
+                cmd.addString("stop");
+                analyzerPort.write(cmd,rep);
+
                 speak("ouch",true);
                 disengage();
             }


### PR DESCRIPTION
There was a missing stop command to `motionAnalyzer`, that was preventing it (and thus the `skeletonScaler`) to stop in case of unexpected event.