### PR TITLE
Setting twarp for the scaler depending on the template

### DIFF
--- a/app/scripts/AssistiveRehab-faces.xml.template
+++ b/app/scripts/AssistiveRehab-faces.xml.template
@@ -98,7 +98,6 @@
 
     <module>
        <name>skeletonScaler</name>
-       <parameters>--twarp 1.0</parameters>
        <node>r1-display-linux</node>
     </module>
 

--- a/app/scripts/AssistiveRehab.xml.template
+++ b/app/scripts/AssistiveRehab.xml.template
@@ -76,7 +76,6 @@
 
     <module>
        <name>skeletonScaler</name>
-       <parameters>--twarp 1.0</parameters>
        <node>r1-display-linux</node>
     </module>
 

--- a/modules/motionAnalyzer/app/conf/motion-repertoire-rom12.ini
+++ b/modules/motionAnalyzer/app/conf/motion-repertoire-rom12.ini
@@ -23,6 +23,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handRight)
 sy_thresh                          (0.3)
 
@@ -35,6 +36,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handRight)
 sy_thresh                          (0.3)
 
@@ -47,6 +49,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handRight)
 sy_thresh                          (0.3)
 
@@ -59,6 +62,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handRight)
 sy_thresh                          (0.3)
 
@@ -71,6 +75,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowRight)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)
@@ -85,6 +90,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowRight)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)
@@ -102,6 +108,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handLeft)
 sy_thresh                          (0.3)
 
@@ -114,6 +121,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handLeft)
 sy_thresh                          (0.3)
 
@@ -126,6 +134,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handLeft)
 sy_thresh                          (0.3)
 
@@ -138,6 +147,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handLeft)
 sy_thresh                          (0.3)
 
@@ -150,6 +160,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowLeft)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)
@@ -164,6 +175,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowLeft)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)

--- a/modules/motionAnalyzer/app/conf/motion-repertoire-rom6-left.ini
+++ b/modules/motionAnalyzer/app/conf/motion-repertoire-rom6-left.ini
@@ -23,6 +23,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handLeft)
 sy_thresh                          (0.3)
 
@@ -35,6 +36,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handLeft)
 sy_thresh                          (0.3)
 
@@ -47,6 +49,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowLeft)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)
@@ -61,6 +64,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowLeft)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)

--- a/modules/motionAnalyzer/app/conf/motion-repertoire-rom6.ini
+++ b/modules/motionAnalyzer/app/conf/motion-repertoire-rom6.ini
@@ -23,6 +23,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handRight)
 sy_thresh                          (0.3)
 
@@ -35,6 +36,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowRight)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)
@@ -49,6 +51,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowRight)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)
@@ -66,6 +69,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handLeft)
 sy_thresh                          (0.3)
 
@@ -78,6 +82,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowLeft)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)
@@ -92,6 +97,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowLeft)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)

--- a/modules/motionAnalyzer/app/conf/motion-repertoire.ini
+++ b/modules/motionAnalyzer/app/conf/motion-repertoire.ini
@@ -23,6 +23,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handRight)
 sy_thresh                          (0.3)
 
@@ -35,6 +36,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                180.0
 duration                           30
+twarp                              1.0
 
 #right shoulder extension
 [ROM_2]
@@ -45,6 +47,7 @@ tag_plane                          sagittal
 min                                -20.0
 max                                60.0
 duration                           30
+twarp                              1.0
 
 #right shoulder internal rotation
 [ROM_3]
@@ -55,6 +58,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowRight)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)
@@ -69,6 +73,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowRight)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)
@@ -83,6 +88,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 
 #right elbow extension
 [ROM_6]
@@ -93,6 +99,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 
 ##################################
 #            LEFT                #
@@ -106,6 +113,7 @@ tag_plane                          coronal
 min                                0.0
 max                                100.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (handLeft)
 sy_thresh                          (0.3)
 
@@ -118,6 +126,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                180.0
 duration                           30
+twarp                              1.0
 
 #left shoulder extension
 [ROM_9]
@@ -128,6 +137,7 @@ tag_plane                          sagittal
 min                                -20.0
 max                                60.0
 duration                           30
+twarp                              1.0
 
 #left shoulder internal rotation
 [ROM_10]
@@ -138,6 +148,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 
 #left shoulder external rotation
 [ROM_11]
@@ -148,6 +159,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 relaxed_list                       (elbowLeft)
 sx_thresh                          (1.0)
 sy_thresh                          (1.0)
@@ -162,6 +174,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 
 #left elbow extension
 [ROM_13]
@@ -172,6 +185,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                90.0
 duration                           30
+twarp                              1.0
 
 #right functional reach
 [EP_0]
@@ -182,6 +196,7 @@ tag_plane                          sagittal
 min                                0.0
 max                                5.0
 duration                           30
+twarp                              1.0
 target                             (2.0 -1.0 0.0)
 
 #left functional reach
@@ -193,4 +208,5 @@ tag_plane                          sagittal
 min                                0.0
 max                                5.0
 duration                           30
+twarp                              1.0
 target                             (2.0 1.0 0.0)

--- a/modules/motionAnalyzer/include/Metric.h
+++ b/modules/motionAnalyzer/include/Metric.h
@@ -32,6 +32,7 @@ protected:
     yarp::sig::Vector ref_dir;
     double min;
     double max;
+    double twarp;
     yarp::sig::Vector camerapos;
     yarp::sig::Vector focalpoint;
     std::vector<std::string> relaxed_joints;
@@ -51,7 +52,7 @@ public:
     void print();
     void initialize(const std::string &name_, const std::string &motion_type_, const std::string &tag_joint_,
                     const yarp::sig::Vector &ref_dir_, const std::string &tag_plane_, const double &min_, const double &max_,
-                    const int &duration_, const yarp::sig::Vector &camerapos_,
+                    const int &duration_, const double &twarp_, const yarp::sig::Vector &camerapos_,
                     const yarp::sig::Vector &focalpoint_, const std::vector<std::string> &relaxed_joints_,
                     const yarp::sig::Vector &dtw_thresh_, const yarp::sig::Vector &mean_thresh_,
                     const yarp::sig::Vector &sx_thresh_, const yarp::sig::Vector &sy_thresh_, const yarp::sig::Vector &sz_thresh_,
@@ -61,6 +62,7 @@ public:
     double getMax() const { return max; }
     double getMin() const { return min; }
     int getDuration() const { return duration; }
+    double getTwarp() const { return twarp; }
     std::string getName() const { return name; }
     std::string getTagPlane() const { return tag_plane; }
     std::string getTagJoint() const { return tag_joint; }

--- a/modules/motionAnalyzer/src/Manager.cpp
+++ b/modules/motionAnalyzer/src/Manager.cpp
@@ -130,6 +130,7 @@ bool Manager::loadMotionList()
                             double min = bMotion.find("min").asDouble();
                             double max = bMotion.find("max").asDouble();
                             int duration = bMotion.find("duration").asInt();
+                            double twarp = bMotion.find("twarp").asDouble();
                             Vector camerapos;
                             camerapos.resize(3);
                             if(Bottle *bCamerapos = bMotion.find("camerapos").asList())
@@ -260,7 +261,7 @@ bool Manager::loadMotionList()
                             }
 
                             metric_repertoire->initialize(curr_tag, motion_type, tag_joint, ref_dir, tag_plane,
-                                                          min, max, duration, camerapos, focalpoint,
+                                                          min, max, duration, twarp, camerapos, focalpoint,
                                                           relaxed_joints,relaxed_dtw_thresh,relaxed_mean_thresh,
                                                           relaxed_sx_thresh,relaxed_sy_thresh, relaxed_sz_thresh,
                                                           relaxed_f_static,relaxed_range_freq,relaxed_psd_thresh);
@@ -435,6 +436,7 @@ bool Manager::start()
 
     Bottle cmd,reply;
     cmd.addVocab(Vocab::encode("run"));
+    cmd.addDouble(metric->getTwarp());
     scalerPort.write(cmd,reply);
     if(reply.get(0).asVocab()!=Vocab::encode("ok"))
     {
@@ -463,7 +465,9 @@ bool Manager::start()
     processor->setInitialConf(skeletonIn);
 
     //start alignmentManager
+    cmd.clear();
     reply.clear();
+    cmd.addVocab(Vocab::encode("run"));
     cmd.addInt(metric->getDuration());
     actionPort.write(cmd,reply);
     if(reply.get(0).asVocab()!=Vocab::encode("ok"))

--- a/modules/motionAnalyzer/src/Metric.cpp
+++ b/modules/motionAnalyzer/src/Metric.cpp
@@ -28,10 +28,10 @@ Metric::~Metric()
 
 void Metric::initialize(const string &name_, const string &motion_type_, const string &tag_joint_, const Vector &ref_dir_,
                         const string &tag_plane_, const double &min_, const double &max_, const int &duration_,
-                        const Vector &camerapos_, const Vector &focalpoint_, const vector<string> &relaxed_joints_,
-                        const Vector &dtw_thresh_, const Vector &mean_thresh_, const Vector &sx_thresh_,
-                        const Vector &sy_thresh_, const Vector &sz_thresh_, const Vector &f_static_,
-                        const Vector &range_freq_, const Vector &psd_thresh_)
+                        const double &twarp_, const Vector &camerapos_, const Vector &focalpoint_,
+                        const vector<string> &relaxed_joints_, const Vector &dtw_thresh_, const Vector &mean_thresh_,
+                        const Vector &sx_thresh_, const Vector &sy_thresh_, const Vector &sz_thresh_,
+                        const Vector &f_static_, const Vector &range_freq_, const Vector &psd_thresh_)
 {
     name = name_;
     motion_type = motion_type_;
@@ -41,6 +41,7 @@ void Metric::initialize(const string &name_, const string &motion_type_, const s
     min = min_;
     max = max_;
     duration = duration_;
+    twarp = twarp_;
     camerapos = camerapos_;
     focalpoint = focalpoint_;
     relaxed_joints = relaxed_joints_;

--- a/modules/skeletonScaler/src/main.cpp
+++ b/modules/skeletonScaler/src/main.cpp
@@ -37,7 +37,6 @@ class Scaler : public RFModule
 //    string context;
     double opacity;
     int nsessions;
-    double twarp;
     double tbegin;
 
     bool hasStarted;
@@ -55,7 +54,6 @@ class Scaler : public RFModule
         attach(rpcPort);
 
         nsessions=rf.check("nsessions",Value(0)).asInt();
-        twarp=rf.check("twarp",Value(0.5)).asDouble();
         tbegin=rf.check("tbegin",Value(0.0)).asDouble();
 
         hasStarted=false;
@@ -117,6 +115,7 @@ class Scaler : public RFModule
         }
         if(command.get(0).asString() == "run")
         {
+            double twarp = command.get(1).asDouble();
             if(start(nsessions,twarp))
             {
                 reply.addVocab(Vocab::encode("ok"));


### PR DESCRIPTION
This PR sets the parameter `twarp` responsible for the speed of the template depending on the template, such that different templates can have different speeds.