### PR TITLE
Replace yarp::os::Mutex with std::mutex

### DIFF
--- a/modules/attentionManager/src/main.cpp
+++ b/modules/attentionManager/src/main.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <cstdlib>
+#include <mutex>
 #include <memory>
 #include <vector>
 #include <string>
@@ -58,7 +59,7 @@ class Attention : public RFModule, public attentionManager_IDL
     string keypoint;
     string robot_skeleton_name;
 
-    Mutex mutex;
+    mutex mtx;
     BufferedPort<Bottle> opcPort;
     RpcClient gazeCmdPort;
     BufferedPort<Property> gazeStatePort;
@@ -80,7 +81,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     bool look(const string &tag, const string &keypoint) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (state<State::idle)
         {
             return false;
@@ -101,7 +102,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     bool stop() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (state<State::idle)
         {
             return false;
@@ -116,7 +117,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     bool is_running() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (state<State::idle)
         {
             return false;
@@ -127,7 +128,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     FollowedSkeletonInfo is_following() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         FollowedSkeletonInfo info;
         if (state==State::follow)
         {
@@ -147,7 +148,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     vector<string> is_any_raised_hand() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         vector<string> ret;
         if (state>=State::idle)
         {
@@ -165,7 +166,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     bool is_with_raised_hand(const string &tag) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (state<State::idle)
         {
             return false;
@@ -183,7 +184,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     bool set_auto() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (state<State::idle)
         {
             return false;
@@ -195,7 +196,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     bool set_virtual() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         virtual_mode=true;
         return true;
     }
@@ -236,7 +237,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     bool set_robot_skeleton_name(const string &robot_skeleton_name_) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         robot_skeleton_name=robot_skeleton_name_;
         return true;
     }
@@ -451,7 +452,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     bool updateModule() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (Property *p=gazeStatePort.read(false))
         {
             Vector pose;

--- a/modules/faceRecognizer/include/queryThread.h
+++ b/modules/faceRecognizer/include/queryThread.h
@@ -23,8 +23,6 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/os/Mutex.h>
-#include <yarp/os/LockGuard.h>
 #include <yarp/os/RpcClient.h>
 #include <yarp/os/PortReport.h>
 #include <yarp/os/Stamp.h>
@@ -40,7 +38,8 @@
 #include <opencv2/imgproc.hpp>
 #include <cv.h>
 
-#include <stdio.h>
+#include <cstdio>
+#include <mutex>
 #include <string>
 #include <deque>
 #include <algorithm>
@@ -57,7 +56,7 @@ class QueryThread: public yarp::os::PeriodicThread
 private:
 
     yarp::os::ResourceFinder                    &rf;
-    yarp::os::Mutex                             mutex;
+    std::mutex                                  mtx;
     bool                                        verbose;
     
     yarp::os::BufferedPort<yarp::os::Bottle>    port_in_scores;    
@@ -72,7 +71,7 @@ private:
     bool                                        allowedTrain;
     std::list<yarp::os::Bottle>                 scores_buffer;
 
-    yarp::os::Mutex img_mutex; int img_cnt;
+    std::mutex img_mtx; int img_cnt;
     std::pair<yarp::sig::ImageOf<yarp::sig::PixelRgb>,yarp::os::Stamp> img_buffer;
     bool getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb> &img, yarp::os::Stamp &stamp);
 

--- a/modules/faceRecognizer/src/queryThread.cpp
+++ b/modules/faceRecognizer/src/queryThread.cpp
@@ -21,7 +21,7 @@
 /********************************************************/
 bool QueryThread::threadInit()
 {
-    yarp::os::LockGuard lg(mutex);
+    std::lock_guard<std::mutex> lg(mtx);
     verbose = rf.check("verbose");
     std::string name = rf.find("name").asString().c_str();
     skip_frames = rf.check("skip_frames",yarp::os::Value(5)).asInt();
@@ -45,7 +45,7 @@ bool QueryThread::threadInit()
 void QueryThread::setImage(const yarp::sig::ImageOf<yarp::sig::PixelRgb> &img,
                            const yarp::os::Stamp &stamp)
 {
-    yarp::os::LockGuard lg(img_mutex);
+    std::lock_guard<std::mutex> lg(img_mtx);
     img_buffer=std::make_pair(img,stamp);
     img_cnt++;
 }
@@ -54,7 +54,7 @@ void QueryThread::setImage(const yarp::sig::ImageOf<yarp::sig::PixelRgb> &img,
 bool QueryThread::getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb> &img,
                            yarp::os::Stamp &stamp)
 {
-    yarp::os::LockGuard lg(img_mutex);
+    std::lock_guard<std::mutex> lg(img_mtx);
     if (img_cnt>0)
     {
         img=img_buffer.first;
@@ -71,7 +71,7 @@ void QueryThread::run()
 {
     if (personIndex>-1)
     {
-        yarp::os::LockGuard lg(mutex);
+        std::lock_guard<std::mutex> lg(mtx);
         yarp::sig::ImageOf<yarp::sig::PixelRgb> img;
         yarp::os::Stamp stamp;
         if (!getImage(img,stamp))
@@ -140,7 +140,7 @@ void QueryThread::run()
 /********************************************************/
 yarp::os::Bottle QueryThread::classify(yarp::os::Bottle &persons)
 {
-    yarp::os::LockGuard lg(mutex);
+    std::lock_guard<std::mutex> lg(mtx);
     yarp::os::Bottle reply;
 
     // as classify() gets called within the same thread that calls
@@ -214,7 +214,7 @@ yarp::os::Bottle QueryThread::classify(yarp::os::Bottle &persons)
 /********************************************************/
 bool QueryThread::set_skip_frames(int skip_frames)
 {
-    yarp::os::LockGuard lg(mutex);
+    std::lock_guard<std::mutex> lg(mtx);
     if (skip_frames>=0)
     {
         this->skip_frames = skip_frames;
@@ -227,7 +227,7 @@ bool QueryThread::set_skip_frames(int skip_frames)
 /********************************************************/
 bool QueryThread::set_person(yarp::os::Bottle &person, int personIndex, bool allowTrain)
 {
-    yarp::os::LockGuard lg(mutex);
+    std::lock_guard<std::mutex> lg(mtx);
     if (person.size()>0)
     {
         this->allowedTrain = allowTrain;
@@ -242,7 +242,7 @@ bool QueryThread::set_person(yarp::os::Bottle &person, int personIndex, bool all
 /********************************************************/
 bool QueryThread::clear_hist()
 {
-    yarp::os::LockGuard lg(mutex);
+    std::lock_guard<std::mutex> lg(mtx);
     scores_buffer.clear();
     return true;
 }

--- a/modules/feedbackProducer/src/main.cpp
+++ b/modules/feedbackProducer/src/main.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <cstdlib>
+#include <mutex>
 #include <algorithm>
 #include <fstream>
 #include <fftw3.h>
@@ -48,7 +49,7 @@ private:
     bool first;
     bool use_robot_template,mirror_robot_template;
 
-    Mutex mutex;
+    mutex mtx;
 
     SkeletonStd skeletonIn,skeletonTemplate;
     string skel_tag,template_tag,metric_tag;
@@ -72,7 +73,7 @@ public:
     /****************************************************************/
     bool setFeedbackThresh(const Matrix &feedback_thresholds) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         this->feedback_thresholds = feedback_thresholds;
         yInfo() << "Feedback thresholds" << feedback_thresholds.toString();
         return true;
@@ -81,7 +82,7 @@ public:
     /****************************************************************/
     bool setTarget(const vector<double> &target) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         this->target = target;
         yInfo() << "Target to reach" << target;
         return true;
@@ -90,7 +91,7 @@ public:
     /****************************************************************/
     bool setTransformation(const Matrix &T) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         this->T = T;
         yInfo() << "Transformation matrix" << T.toString();
         return true;
@@ -99,7 +100,7 @@ public:
     /****************************************************************/
     bool setTemplateTag(const string &template_tag) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         this->template_tag = template_tag;
         yInfo() << "Template skeleton" << template_tag;
         return true;
@@ -108,7 +109,7 @@ public:
     /****************************************************************/
     bool setSkelTag(const string &skel_tag) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         this->skel_tag = skel_tag;
         yInfo() << "Tag skeleton" << skel_tag;
         return true;
@@ -117,7 +118,7 @@ public:
     /****************************************************************/
     bool setMetric(const string &metric_tag) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         this->metric_tag = metric_tag;
         yInfo() << "Metric tag" << metric_tag;
         return true;
@@ -126,7 +127,7 @@ public:
     /****************************************************************/
     bool setJoints(const vector<string> &joint_list) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         yInfo() << "Joint list";
         this->joint_list.resize(joint_list.size());
         for(size_t i=0; i<joint_list.size(); i++)
@@ -141,7 +142,7 @@ public:
     bool setRobotTemplate(const bool use_robot_template,
                           const bool mirror_robot_template) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         this->use_robot_template = use_robot_template;
         this->mirror_robot_template = mirror_robot_template;
         yInfo() << "Using robot template";
@@ -151,7 +152,7 @@ public:
     /****************************************************************/
     bool setPart(const string &part) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         this->part=part;
         yInfo() << "Analyzing"<<part<<"part";
         return true;
@@ -160,7 +161,7 @@ public:
     /****************************************************************/
     bool start() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         yInfo() << "Start!";
         started = true;
         first = true;
@@ -170,7 +171,7 @@ public:
     /****************************************************************/
     bool stop() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         yInfo() << "Stop!";
         skel_tag.clear();
         template_tag.clear();
@@ -661,7 +662,7 @@ public:
     /********************************************************/
     bool updateModule() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
 
         //if we query the database
         if(opcPort.getOutputCount() > 0 && started)

--- a/modules/interactionManager/src/main.cpp
+++ b/modules/interactionManager/src/main.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <cstdlib>
+#include <mutex>
 #include <cmath>
 #include <iterator>
 #include <unordered_map>
@@ -210,7 +211,7 @@ class Interaction : public RFModule, public interactionManager_IDL
     bool imitate,observe;
     string partspeech;
 
-    Mutex mutex;
+    mutex mtx;
 
     RpcClient attentionPort;
     RpcClient analyzerPort;
@@ -226,7 +227,7 @@ class Interaction : public RFModule, public interactionManager_IDL
     /****************************************************************/
     bool start_with_hand() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         engage_with_hand=true;
         wait_for_imitation=false;
         return disengage();
@@ -235,7 +236,7 @@ class Interaction : public RFModule, public interactionManager_IDL
     /****************************************************************/
     bool start_observation() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         engage_with_hand=false;
         wait_for_imitation=true;
         observe=true;
@@ -245,7 +246,7 @@ class Interaction : public RFModule, public interactionManager_IDL
     /****************************************************************/
     bool start_imitation() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         imitate=true;
         return true;
     }
@@ -253,7 +254,7 @@ class Interaction : public RFModule, public interactionManager_IDL
     /****************************************************************/
     bool start_occlusion() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         occluded=true;
         if(virtual_mode)
         {
@@ -312,7 +313,7 @@ class Interaction : public RFModule, public interactionManager_IDL
     /****************************************************************/
     bool stop() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         bool ret=false;
 
         Bottle cmd,rep;
@@ -754,7 +755,7 @@ class Interaction : public RFModule, public interactionManager_IDL
     /****************************************************************/
     bool updateModule() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if ((attentionPort.getOutputCount()==0) || (analyzerPort.getOutputCount()==0) ||
                 (speechStreamPort.getOutputCount()==0) || (speechRpcPort.getOutputCount()==0) ||
                 (robotSkeletonPort.getOutputCount()==0))

--- a/modules/motionAnalyzer/include/Manager.h
+++ b/modules/motionAnalyzer/include/Manager.h
@@ -13,6 +13,7 @@
 #ifndef __MANAGER_H__
 #define __MANAGER_H__
 
+#include <mutex>
 #include <fstream>
 #include <list>
 
@@ -72,7 +73,7 @@ class Manager : public yarp::os::RFModule,
     std::string out_folder;
     bool updated;
     std::string prop_tag;
-    yarp::os::Mutex mutex;
+    std::mutex mtx;
 
     bool loadMotionList(yarp::os::ResourceFinder &rf);
     bool loadExercise(const std::string &exercise_tag) override;

--- a/modules/motionAnalyzer/src/Manager.cpp
+++ b/modules/motionAnalyzer/src/Manager.cpp
@@ -33,7 +33,7 @@ using namespace assistive_rehab;
 
 bool Manager::loadMotionList(ResourceFinder &rf)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
 
     rf.setVerbose();
     rf.setDefaultContext(this->rf->getContext().c_str());
@@ -302,7 +302,7 @@ bool Manager::loadMotionList(ResourceFinder &rf)
 /********************************************************/
 bool Manager::setTemplateTag(const string &template_tag)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
 
     this->template_tag=template_tag;
     Bottle cmd,reply;
@@ -322,7 +322,7 @@ bool Manager::setTemplateTag(const string &template_tag)
 /********************************************************/
 bool Manager::loadExercise(const string &exercise_tag)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     if(motion_repertoire.count(exercise_tag))
     {
         curr_exercise=motion_repertoire.at(exercise_tag);
@@ -395,7 +395,7 @@ bool Manager::loadExercise(const string &exercise_tag)
 /********************************************************/
 string Manager::getExercise()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     if(curr_exercise!=NULL)
         return curr_exercise->getName();
     else
@@ -406,7 +406,7 @@ string Manager::getExercise()
 /********************************************************/
 vector<string> Manager::listExercises()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     vector<string> reply;
     for (auto it=motion_repertoire.begin(); it!=motion_repertoire.end(); it++)
     {
@@ -419,7 +419,7 @@ vector<string> Manager::listExercises()
 /********************************************************/
 vector<string> Manager::listMetricProps()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     if(curr_metric!=NULL)
         return curr_metric->getProperties();
     else
@@ -429,7 +429,7 @@ vector<string> Manager::listMetricProps()
 /********************************************************/
 vector<string> Manager::listJoints()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     vector<string> reply;
     if(curr_exercise!=NULL && curr_exercise->getType()==ExerciseType::rehabilitation)
     {
@@ -449,7 +449,7 @@ vector<string> Manager::listJoints()
 /********************************************************/
 bool Manager::selectSkel(const string &skel_tag)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
 
     this->skel_tag=skel_tag;
     yInfo() << "Analyzing skeleton " << this->skel_tag.c_str();
@@ -494,7 +494,7 @@ bool Manager::selectSkel(const string &skel_tag)
 /********************************************************/
 bool Manager::setPart(const string &part)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
 
     yInfo() << "Moving" << part << "arm";
     Bottle cmd,reply;
@@ -525,7 +525,7 @@ bool Manager::setPart(const string &part)
 /********************************************************/
 bool Manager::mirrorTemplate(const bool robot_skeleton_mirror)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     this->robot_skeleton_mirror=robot_skeleton_mirror;
     return true;
 }
@@ -533,7 +533,7 @@ bool Manager::mirrorTemplate(const bool robot_skeleton_mirror)
 /********************************************************/
 bool Manager::selectMetricProp(const string &prop_tag)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     if(curr_exercise!=NULL)
     {
         this->prop_tag=prop_tag;
@@ -550,14 +550,14 @@ bool Manager::selectMetricProp(const string &prop_tag)
 /********************************************************/
 string Manager::getCurrMetricProp()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     return prop_tag;
 }
 
 /********************************************************/
 vector<string> Manager::listMetrics()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     if(curr_exercise!=NULL)
     {
         return curr_exercise->listMetrics();
@@ -572,7 +572,7 @@ vector<string> Manager::listMetrics()
 /********************************************************/
 bool Manager::selectMetric(const string &metric_tag)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     if(curr_exercise!=NULL)
     {
         curr_metric=curr_exercise->getCurrMetric(metric_tag);
@@ -619,7 +619,7 @@ bool Manager::selectMetric(const string &metric_tag)
 /********************************************************/
 bool Manager::start(const bool use_robot_template)
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
                 
     this->use_robot_template = use_robot_template;
     yInfo() << "Start!";
@@ -762,7 +762,7 @@ bool Manager::start(const bool use_robot_template)
 /********************************************************/
 bool Manager::stopFeedback()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
 
     yInfo() << "Stop feedback!";
 
@@ -780,7 +780,7 @@ bool Manager::stopFeedback()
 /********************************************************/
 bool Manager::stop()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
     yInfo()<<"stopping";
 
     if(curr_exercise->getType()==ExerciseType::rehabilitation)
@@ -994,7 +994,7 @@ double Manager::getPeriod()
 /********************************************************/
 bool Manager::updateModule()
 {
-    LockGuard lg(mutex);
+    lock_guard<mutex> lg(mtx);
 
     //if we query the database
     if(opcPort.getOutputCount()>0 && starting)

--- a/modules/robotSkeletonPublisher/src/main.cpp
+++ b/modules/robotSkeletonPublisher/src/main.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <cstdlib>
+#include <mutex>
 #include <string>
 #include <vector>
 #include <utility>
@@ -26,8 +27,6 @@
 #include <yarp/os/RpcClient.h>
 #include <yarp/os/RpcServer.h>
 #include <yarp/os/Stamp.h>
-#include <yarp/os/LockGuard.h>
-#include <yarp/os/Mutex.h>
 
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
@@ -78,7 +77,7 @@ class Publisher : public RFModule, public robotSkeletonPublisher_IDL
     int opc_id;
 
     RpcServer cmdPort;
-    Mutex mutex;
+    mutex mtx;
     bool visibility;
 
     HeadSolver head;
@@ -140,7 +139,7 @@ class Publisher : public RFModule, public robotSkeletonPublisher_IDL
     /**************************************************************************/
     bool set_visibility(const bool flag) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         visibility=flag;
         return true;
     }
@@ -148,7 +147,7 @@ class Publisher : public RFModule, public robotSkeletonPublisher_IDL
     /**************************************************************************/
     bool set_robot_skeleton_name(const string &skeleton_name) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         this->skeleton_name=skeleton_name;
         return true;
     }
@@ -319,7 +318,7 @@ class Publisher : public RFModule, public robotSkeletonPublisher_IDL
     /**************************************************************************/
     bool updateModule() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
 
         // update joints state and time stamps
         Vector stamps;

--- a/modules/skeletonPlayer/src/main.cpp
+++ b/modules/skeletonPlayer/src/main.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <cstdlib>
+#include <mutex>
 #include <memory>
 #include <vector>
 #include <iterator>
@@ -42,7 +43,7 @@ struct MetaSkeleton
 /****************************************************************/
 class Player : public RFModule, public skeletonPlayer_IDL
 {
-    Mutex mutex;
+    mutex mtx;
     vector<MetaSkeleton> skeletons;
     vector<MetaSkeleton>::iterator it,it_begin,it_end;
     enum class State { idle, loaded, opced, running } state;
@@ -184,7 +185,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool load(const string& file, const string& context) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         ResourceFinder rf;
 
         rf.setQuiet();
@@ -261,7 +262,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     bool start(const int n_sessions, const double t_warp,
                const double t_begin, const double t_end) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if ((state==State::loaded) || (state==State::opced))
         {
             if (findFrameDirect(begin(skeletons),t_begin,it_begin) &&
@@ -292,7 +293,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool stop() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (state==State::running)
         {
             yInfo()<<"Streaming ended";
@@ -304,14 +305,14 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool is_running() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         return (state==State::running);
     }
 
     /****************************************************************/
     bool put_in_opc(const double t_begin) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (skeletons.empty())
         {
             yError()<<"No file loaded yet!";
@@ -342,7 +343,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool remove_from_opc() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if ((state==State::opced) || (state==State::running))
         {
             if (opcDel())
@@ -359,7 +360,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool set_tag(const string& new_tag) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (skeletons.empty())
         {
             yError()<<"No file loaded yet!";
@@ -376,7 +377,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     double get_maxpath(const double t_begin) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (skeletons.empty())
         {
             yError()<<"No file loaded yet!";
@@ -408,7 +409,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool normalize() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (skeletons.empty())
         {
             yError()<<"No file loaded yet!";
@@ -425,7 +426,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool scale(const double s) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (skeletons.empty())
         {
             yError()<<"No file loaded yet!";
@@ -442,7 +443,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool move(const Matrix &T) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (skeletons.empty())
         {
             yError()<<"No file loaded yet!";
@@ -464,7 +465,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool set_opacity(const double new_opacity) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         opacity=new_opacity;
         return true;
     }
@@ -472,7 +473,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool set_color(const double new_r, const double new_g, const double new_b) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         color.clear();
         Bottle &c=color.addList();
         c.addDouble(new_r);
@@ -512,7 +513,7 @@ class Player : public RFModule, public skeletonPlayer_IDL
     /****************************************************************/
     bool updateModule() override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         double t=Time::now()-t_origin;
         if (state==State::running)
         {

--- a/modules/skeletonViewer/main.cpp
+++ b/modules/skeletonViewer/main.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <cstdlib>
+#include <mutex>
 #include <memory>
 #include <cmath>
 #include <limits>
@@ -338,7 +339,7 @@ public:
 };
 
 
-Mutex mutex;
+mutex mtx;
 vector<Bottle> inputs;
 bool rpc_command_rx;
 Vector camera_position,camera_focalpoint,camera_viewup;
@@ -374,7 +375,7 @@ public:
     void Execute(vtkObject *caller, unsigned long vtkNotUsed(eventId), 
                  void *vtkNotUsed(callData))
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         vtkRenderWindowInteractor* iren=static_cast<vtkRenderWindowInteractor*>(caller);
 
         if (closing!=nullptr)
@@ -578,14 +579,14 @@ class Viewer : public RFModule
     /****************************************************************/
     void process(const Bottle &input)
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         inputs.push_back(input);
     }
 
     /****************************************************************/
     void gc()
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         double t=Time::now();
         double deadline=skeletonsGC.getPeriod();
 
@@ -597,7 +598,7 @@ class Viewer : public RFModule
     /****************************************************************/
     bool respond(const Bottle &command, Bottle &reply) override
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         if (command.size()>0)
         {
             string cmd=command.get(0).asString();


### PR DESCRIPTION
This PR cleans up our code in order to replace occurrences of `yarp::os::Mutex` and `yarp::os::LockGuard` with the standard counterparts `std::mutex` and `std::lock_guard<>`, respectively.

Typical usage
```c++
#include <mutex>
//...
std::mutex mtx;
std::lock_guard<std::mutex> lg(mtx);
```

@vvasco please rebase your feature branches upon `master`, once merged.