### PR TITLE
Navigation during TUG

### DIFF
--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -58,6 +58,17 @@
     </module>
 
     <module>
+       <name>navController</name>
+       <parameters></parameters>
+       <dependencies>
+         <port>/baseControl/rpc</port>
+         <port>/baseControl/odometry:o</port>
+         <port>/baseControl/control:i</port>
+       </dependencies>
+       <node>r1-console-linux</node>
+    </module>
+
+    <module>
        <name>cer_gaze-controller</name>
        <parameters>--cameras::context cameraCalibration --cameras::file cerEyes_320x240.ini --joints-limits::pitch "(-20.0 20.0)" --joints-limits::yaw "(-40.0 40.0)"</parameters>
        <ensure>
@@ -201,7 +212,7 @@
     <connection>
         <from>/lineDetector/cam:rpc</from>
         <to>/depthCamera/rpc:i</to>
-        <protocol>tcp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
@@ -247,6 +258,18 @@
     </connection>
 
     <connection>
+        <from>/opc/broadcast:o</from>
+        <to>/navController/opc:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/cer_gaze-controller/state:o</from>
+        <to>/navController/gaze:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
         <from>/managerTUG/attention:rpc</from>
         <to>/attentionManager/cmd:rpc</to>
         <protocol>fast_tcp</protocol>
@@ -269,4 +292,11 @@
         <to>/iSpeak/rpc</to>
         <protocol>fast_tcp</protocol>
     </connection>
+
+    <connection>
+        <from>/managerTUG/navigation:rpc</from>
+        <to>/navController/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
 </application>

--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -228,6 +228,12 @@
     </connection>
 
     <connection>
+        <from>/lineDetector/nav:rpc</from>
+        <to>/navController/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
         <from>/motionAnalyzer/opc</from>
         <to>/opc/rpc</to>
         <protocol>fast_tcp</protocol>
@@ -278,6 +284,12 @@
     <connection>
         <from>/managerTUG/analyzer:rpc</from>
         <to>/motionAnalyzer/cmd</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/line:rpc</from>
+        <to>/lineDetector/cmd:rpc</to>
         <protocol>fast_tcp</protocol>
     </connection>
 

--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -52,6 +52,12 @@
     </module>
 
     <module>
+       <name>robotSkeletonPublisher</name>
+       <parameters></parameters>
+       <node>r1-console-linux</node>
+    </module>
+
+    <module>
        <name>attentionManager</name>
        <parameters></parameters>
        <node>r1-console-linux</node>
@@ -180,6 +186,24 @@
     </connection>
 
     <connection>
+        <from>/cer_gaze-controller/state:o</from>
+        <to>/skeletonRetriever/gaze:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/navController/state:o</from>
+        <to>/skeletonRetriever/nav:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/navController/state:o</from>
+        <to>/robotSkeletonPublisher/nav:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
         <from>/opc/broadcast:o</from>
         <to>/attentionManager/opc:i</to>
         <protocol>fast_tcp</protocol>
@@ -230,6 +254,12 @@
     <connection>
         <from>/lineDetector/nav:rpc</from>
         <to>/navController/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/lineDetector/viewer:rpc</from>
+        <to>/skeletonViewer:rpc</to>
         <protocol>fast_tcp</protocol>
     </connection>
 

--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -97,7 +97,7 @@
 
     <module>
         <name>managerTUG</name>
-        <parameters>--standing-thresh 0.3 --finish-line-thresh 0.2</parameters>
+        <parameters>--standing-thresh 0.2 --finish-line-thresh 0.3</parameters>
         <node>r1-console-linux</node>
     </module>
 
@@ -121,7 +121,7 @@
 
     <module>
         <name>skeletonViewer</name>
-        <parameters>--x 1120 --y 10</parameters>
+        <parameters>--x 1120 --y 10 --show-floor on --camera-viewup "(1.0 0.0 0.0)" --camera-position "(-4.0 -2.0 8.0)" --camera-focalpoint "(0.0 -2.0 0.0)"</parameters>
         <node>r1-display-linux</node>
     </module>
 
@@ -302,12 +302,6 @@
     <connection>
         <from>/opc/broadcast:o</from>
         <to>/navController/opc:i</to>
-        <protocol>fast_tcp</protocol>
-    </connection>
-
-    <connection>
-        <from>/cer_gaze-controller/state:o</from>
-        <to>/navController/gaze:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
 

--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -52,13 +52,13 @@
     </module>
 
     <module>
-       <name>robotSkeletonPublisher</name>
+       <name>attentionManager</name>
        <parameters></parameters>
        <node>r1-console-linux</node>
     </module>
 
     <module>
-       <name>attentionManager</name>
+       <name>robotSkeletonPublisher</name>
        <parameters></parameters>
        <node>r1-console-linux</node>
     </module>
@@ -198,12 +198,6 @@
     </connection>
 
     <connection>
-        <from>/navController/state:o</from>
-        <to>/robotSkeletonPublisher/nav:i</to>
-        <protocol>fast_tcp</protocol>
-    </connection>
-
-    <connection>
         <from>/opc/broadcast:o</from>
         <to>/attentionManager/opc:i</to>
         <protocol>fast_tcp</protocol>
@@ -218,12 +212,6 @@
     <connection>
         <from>/cer_gaze-controller/state:o</from>
         <to>/attentionManager/gaze/state:i</to>
-        <protocol>fast_tcp</protocol>
-    </connection>
-
-    <connection>
-        <from>/cer_gaze-controller/state:o</from>
-        <to>/motionAnalyzer/gaze:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
 
@@ -289,6 +277,24 @@
 
     <connection>
         <from>/skeletonRetriever/viewer:o</from>
+        <to>/skeletonViewer:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/robotSkeletonPublisher/opc:rpc</from>
+        <to>/opc/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/navController/state:o</from>
+        <to>/robotSkeletonPublisher/nav:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/robotSkeletonPublisher/viewer:o</from>
         <to>/skeletonViewer:i</to>
         <protocol>fast_tcp</protocol>
     </connection>

--- a/app/scripts/AssistiveRehab-faces.xml.template
+++ b/app/scripts/AssistiveRehab-faces.xml.template
@@ -324,12 +324,6 @@
     </connection>
 
     <connection>
-        <from>/cer_gaze-controller/state:o</from>
-        <to>/motionAnalyzer/gaze:i</to>
-        <protocol>fast_tcp</protocol>
-    </connection>
-
-    <connection>
         <from>/motionAnalyzer/opc</from>
         <to>/opc/rpc</to>
         <protocol>fast_tcp</protocol>

--- a/app/scripts/AssistiveRehab.xml.template
+++ b/app/scripts/AssistiveRehab.xml.template
@@ -242,12 +242,6 @@
     </connection>
 
     <connection>
-        <from>/cer_gaze-controller/state:o</from>
-        <to>/motionAnalyzer/gaze:i</to>
-        <protocol>fast_tcp</protocol>
-    </connection>
-
-    <connection>
         <from>/motionAnalyzer/opc</from>
         <to>/opc/rpc</to>
         <protocol>fast_tcp</protocol>

--- a/modules/attentionManager/CMakeLists.txt
+++ b/modules/attentionManager/CMakeLists.txt
@@ -13,7 +13,7 @@ source_group("DOC Files" FILES ${doc_files})
 
 add_executable(${PROJECT_NAME} src/main.cpp src/idl.thrift ${IDL_GEN_FILES} ${doc_files})
 target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
-target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ctrlLib AssistiveRehab)
+target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} AssistiveRehab)
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 
 file(GLOB scripts app/scripts/*.template)

--- a/modules/attentionManager/src/idl.thrift
+++ b/modules/attentionManager/src/idl.thrift
@@ -103,10 +103,9 @@ service attentionManager_IDL
 
    /**
     * Enable autonomous mode.
-    * @param seek_for_finish_line set this to true for TUG.
     * @return true/false on success/failure.
     */
-   bool set_auto(1:bool seek_for_finish_line=false);
+   bool set_auto();
 
    /**
     * Enable virtual scenario mode.
@@ -120,17 +119,5 @@ service attentionManager_IDL
     * @return true/false on success/failure.
     */
    bool set_robot_skeleton_name(1:string robot_skeleton_name);
-
-   /**
-    * Get the pose of the start line.
-    * @return pose of the start line with respect to the robot root.
-    */
-    Vector get_startline_pose();
-
-   /**
-    * Get the pose of the finish line.
-    * @return pose of the finish line with respect to the robot root.
-    */
-    Vector get_finishline_pose();
 
 }

--- a/modules/attentionManager/src/idl.thrift
+++ b/modules/attentionManager/src/idl.thrift
@@ -15,6 +15,13 @@
 *
 * IDL structure to send info on followed skeleton.
 */
+
+struct Vector { }
+(
+   yarp.name="yarp::sig::Vector"
+   yarp.includefile="yarp/sig/Vector.h"
+)
+
 struct FollowedSkeletonInfo
 {
    /**
@@ -36,13 +43,17 @@ struct FollowedSkeletonInfo
    * the z-coordinate.
    */
    4:double z;
-}
 
-struct Vector { }
-(
-   yarp.name="yarp::sig::Vector"
-   yarp.includefile="yarp/sig/Vector.h"
-)
+   /**
+   * the coronal plane.
+   */
+   5:Vector coronal;
+
+   /**
+   * the sagittal plane.
+   */
+   6:Vector sagittal;
+}
 
 /**
  * attentionManager_IDL
@@ -111,9 +122,15 @@ service attentionManager_IDL
    bool set_robot_skeleton_name(1:string robot_skeleton_name);
 
    /**
-    * Get the pose of the finish line.
-    * @return pose of the finish line with respect to the camera.
+    * Get the pose of the start line.
+    * @return pose of the start line with respect to the robot root.
     */
-    Vector get_line_pose();
+    Vector get_startline_pose();
+
+   /**
+    * Get the pose of the finish line.
+    * @return pose of the finish line with respect to the robot root.
+    */
+    Vector get_finishline_pose();
 
 }

--- a/modules/attentionManager/src/main.cpp
+++ b/modules/attentionManager/src/main.cpp
@@ -225,11 +225,11 @@ class Attention : public RFModule, public attentionManager_IDL
         lock_guard<mutex> lg(mtx);
         if (filtered_startline_pose.size()>0)
         {
-            return {};
+            return filtered_startline_pose;
         }
         else
         {
-            return filtered_startline_pose;
+            return {};
         }
     }
 
@@ -239,11 +239,11 @@ class Attention : public RFModule, public attentionManager_IDL
         lock_guard<mutex> lg(mtx);
         if (filtered_finishline_pose.size()>0)
         {
-            return {};
+            return filtered_finishline_pose;
         }
         else
         {
-            return filtered_finishline_pose;
+            return {};
         }
     }
 
@@ -456,6 +456,7 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     bool wait_line_reliable(const string &line)
     {
+        yInfo()<<"Looking for"<<line;
         bool line_found=false;
         if (Bottle *b=opcPort.read())
         {
@@ -649,7 +650,8 @@ class Attention : public RFModule, public attentionManager_IDL
                 {
                     Property prop;
                     prop.fromString(b->get(i).asList()->toString());
-                    if(prop.find("tag").asString()!=robot_skeleton_name && !prop.check("finish-line"))
+                    if(prop.find("tag").asString()!=robot_skeleton_name
+                            && !prop.check("finish-line") && !prop.check("start-line"))
                     {
                         skeletons.push_back(shared_ptr<Skeleton>(skeleton_factory(prop)));
                     }
@@ -663,7 +665,6 @@ class Attention : public RFModule, public attentionManager_IDL
         }
         else if (state==State::seek_lines)
         {
-            yInfo()<<"Looking for start and finish line";
             Vector target(2);
             target[0]=Rand::scalar(-30.0,30.0);
             target[1]=Rand::scalar(-35.0,-15.0);

--- a/modules/lineDetector/CMakeLists.txt
+++ b/modules/lineDetector/CMakeLists.txt
@@ -4,15 +4,18 @@
 
 project(lineDetector)
 
+yarp_add_idl(IDL_GEN_FILES src/idl.thrift)
+
 set(doc_files ${PROJECT_NAME}.xml)
+source_group("IDL Files" FILES src/idl.thrift)
 source_group("DOC Files" FILES ${doc_files})
 
 file(GLOB source src/*.cpp)
 file(GLOB scripts app/scripts/*.template)
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
-add_executable(${PROJECT_NAME} ${source} ${doc_files})
-target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES})
+add_executable(${PROJECT_NAME} ${source} src/idl.thrift ${IDL_GEN_FILES} ${doc_files})
+target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES} ctrlLib)
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 
 yarp_install(FILES ${scripts} DESTINATION ${ICUBCONTRIB_APPLICATIONS_TEMPLATES_INSTALL_DIR})

--- a/modules/lineDetector/src/idl.thrift
+++ b/modules/lineDetector/src/idl.thrift
@@ -1,0 +1,65 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+/**
+ * @file idl.thrift
+ * @authors: Valentina Vasco <valentina.vasco@iit.it>
+ */
+
+struct Vector { }
+(
+   yarp.name="yarp::sig::Vector"
+   yarp.includefile="yarp/sig/Vector.h"
+)
+
+struct Matrix { }
+(
+   yarp.name="yarp::sig::Matrix"
+   yarp.includefile="yarp/sig/Matrix.h"
+)
+
+/**
+ * lineDetector_IDL
+ *
+ * IDL Interface to lineDetector services.
+ */
+service lineDetector_IDL
+{
+  /**
+   * Start detection of start/finish line.
+   * @param line_idx index of the line to detect, 0:start-line, 1:finish-line.
+   * @param timeout optional timeout in seconds, if > 0.
+   * @return true on success/failure.
+   */
+   bool detect(1:i32 line_idx, 2:i32 timeout=0)
+
+   /**
+    * Get the pose of the line.
+    * @param line_idx index of the line, 0:start-line, 1:finish-line.
+    * @return pose of the line with respect to the world frame (start-line).
+    */
+    Vector get_line_pose(1:i32 line_idx);
+
+   /**
+    * Get the transformation matrix from robot root to world frame (start-line).
+    * @return transformation matrix.
+    */
+    Matrix get_world_frame();
+
+   /**
+    * Reset lines.
+    * @return true/false on success/failure.
+    */
+    bool reset();
+
+   /**
+    * Stop detection.
+    * @return true/false on success/failure.
+    */
+    bool stop();
+
+}

--- a/modules/lineDetector/src/idl.thrift
+++ b/modules/lineDetector/src/idl.thrift
@@ -45,12 +45,6 @@ service lineDetector_IDL
     Vector get_line_pose(1:string line);
 
    /**
-    * Get the transformation matrix from robot root to world frame (start-line).
-    * @return transformation matrix.
-    */
-    Matrix get_world_frame();
-
-   /**
     * Reset lines.
     * @return true/false on success/failure.
     */

--- a/modules/lineDetector/src/idl.thrift
+++ b/modules/lineDetector/src/idl.thrift
@@ -31,18 +31,18 @@ service lineDetector_IDL
 {
   /**
    * Start detection of start/finish line.
-   * @param line_idx index of the line to detect, 0:start-line, 1:finish-line.
+   * @param line string indicating the line to detect, start-line or finish-line.
    * @param timeout optional timeout in seconds, if > 0.
    * @return true on success/failure.
    */
-   bool detect(1:i32 line_idx, 2:i32 timeout=0)
+   bool detect(1:string line, 2:i32 timeout=0)
 
    /**
     * Get the pose of the line.
-    * @param line_idx index of the line, 0:start-line, 1:finish-line.
+    * @param line string indicating the line to detect, start-line or finish-line.
     * @return pose of the line with respect to the world frame (start-line).
     */
-    Vector get_line_pose(1:i32 line_idx);
+    Vector get_line_pose(1:string line);
 
    /**
     * Get the transformation matrix from robot root to world frame (start-line).

--- a/modules/managerTUG/app/conf/config-en.ini
+++ b/modules/managerTUG/app/conf/config-en.ini
@@ -1,5 +1,6 @@
 name                      managerTUG
 period                    0.1
 speak-file                speak-en.ini
-finish-line-thresh        0.2
-standing-thresh           0.3
+finish-line-thresh        0.3
+standing-thresh           0.2
+starting-pose             (1.5 -3.0 110.0)

--- a/modules/managerTUG/app/conf/config-it.ini
+++ b/modules/managerTUG/app/conf/config-it.ini
@@ -1,5 +1,6 @@
 name                      managerTUG
 period                    0.1
 speak-file                speak-it.ini
-finish-line-thresh        0.2
-standing-thresh           0.3
+finish-line-thresh        0.3
+standing-thresh           0.2
+starting-pose             (1.5 -3.0 110.0)

--- a/modules/managerTUG/app/conf/speak-en.ini
+++ b/modules/managerTUG/app/conf/speak-en.ini
@@ -1,5 +1,5 @@
 [general]
-num-sections    23
+num-sections    24
 
 [section-0]
 key             "ouch"
@@ -92,3 +92,7 @@ value           "I'm sorry. I don't know how to answer to this question."
 [section-22]
 key             "questions"
 value           "Everything clear?"
+
+[section-23]
+key             "line"
+value           "This is the line that you have to cross."

--- a/modules/managerTUG/app/conf/speak-it.ini
+++ b/modules/managerTUG/app/conf/speak-it.ini
@@ -1,5 +1,5 @@
 [general]
-num-sections    23
+num-sections    24
 
 [section-0]
 key             "ouch"
@@ -92,3 +92,7 @@ value           "Mi dispiace, non so rispondere a questa domanda."
 [section-22]
 key             "questions"
 value           "Tutto chiaro?"
+
+[section-23]
+key             "line"
+value           "Questa è la linea che dovrai superare."

--- a/modules/managerTUG/managerTUG.xml
+++ b/modules/managerTUG/managerTUG.xml
@@ -16,8 +16,9 @@
     <param default="managerTUG" desc="Name of the module. All the open ports will be tagged with the prefix /module_name.">module_name</param>
     <param default="0.1" desc="Periodicity of the module.">period</param>
     <param default="speak-it" desc="Configuration file name for the speak.">speak-file</param>
-    <param default="0.2" desc="Threshold on the distance between foot and finish line [m].">finish-line-thresh</param>
-    <param default="0.3" desc="Threshold on the speed of the shoulder center height [m/s].">standing-thresh</param>
+    <param default="0.3" desc="Threshold on the distance between foot and finish line [m].">finish-line-thresh</param>
+    <param default="0.2" desc="Threshold on the speed of the shoulder center height [m/s].">standing-thresh</param>
+    <param default="(1.5 -3.0 110.0)" desc="Robot initial pose (x,y,theta) wrt world frame when starting the TUG.">starting-pose</param>
   </arguments>
 
   <authors>

--- a/modules/managerTUG/src/main.cpp
+++ b/modules/managerTUG/src/main.cpp
@@ -920,42 +920,32 @@ class Manager : public RFModule, public managerTUG_IDL
                                             yInfo()<<cmd.toString();
                                             cmd.clear();
                                             rep.clear();
-                                            cmd.addString("set_world_frame");
-                                            cmd.addList().read(worldframe);
-                                            if (analyzerPort.write(cmd,rep))
+                                            cmd.addString("get_line_pose");
+                                            cmd.addString("finish-line");
+                                            if(linePort.write(cmd,rep))
                                             {
-                                                if (rep.get(0).asVocab()==ok)
+                                                if(Bottle *lp_bottle=rep.get(0).asList())
                                                 {
-                                                    cmd.clear();
-                                                    rep.clear();
-                                                    cmd.addString("get_line_pose");
-                                                    cmd.addString("finish-line");
-                                                    if(linePort.write(cmd,rep))
+                                                    if(lp_bottle->size()>=7)
                                                     {
-                                                        if(Bottle *lp_bottle=rep.get(0).asList())
-                                                        {
-                                                            if(lp_bottle->size()>=7)
-                                                            {
-                                                                finishline_pose.resize(7);
-                                                                finishline_pose[0]=lp_bottle->get(0).asDouble();
-                                                                finishline_pose[1]=lp_bottle->get(1).asDouble();
-                                                                finishline_pose[2]=lp_bottle->get(2).asDouble();
-                                                                finishline_pose[3]=lp_bottle->get(3).asDouble();
-                                                                finishline_pose[4]=lp_bottle->get(4).asDouble();
-                                                                finishline_pose[5]=lp_bottle->get(5).asDouble();
-                                                                finishline_pose[6]=lp_bottle->get(6).asDouble();
-                                                                yInfo()<<"Finish line wrt world frame"<<finishline_pose.toString();
+                                                        finishline_pose.resize(7);
+                                                        finishline_pose[0]=lp_bottle->get(0).asDouble();
+                                                        finishline_pose[1]=lp_bottle->get(1).asDouble();
+                                                        finishline_pose[2]=lp_bottle->get(2).asDouble();
+                                                        finishline_pose[3]=lp_bottle->get(3).asDouble();
+                                                        finishline_pose[4]=lp_bottle->get(4).asDouble();
+                                                        finishline_pose[5]=lp_bottle->get(5).asDouble();
+                                                        finishline_pose[6]=lp_bottle->get(6).asDouble();
+                                                        yInfo()<<"Finish line wrt world frame"<<finishline_pose.toString();
 
-                                                                cmd.clear();
-                                                                rep.clear();
-                                                                cmd.addString("setLinePose");
-                                                                cmd.addList().read(finishline_pose);
-                                                                if(analyzerPort.write(cmd,rep))
-                                                                {
-                                                                    yInfo()<<"Set finish line to motionAnalyzer";
-                                                                    return true;
-                                                                }
-                                                            }
+                                                        cmd.clear();
+                                                        rep.clear();
+                                                        cmd.addString("setLinePose");
+                                                        cmd.addList().read(finishline_pose);
+                                                        if(analyzerPort.write(cmd,rep))
+                                                        {
+                                                            yInfo()<<"Set finish line to motionAnalyzer";
+                                                            return true;
                                                         }
                                                     }
                                                 }

--- a/modules/managerTUG/src/main.cpp
+++ b/modules/managerTUG/src/main.cpp
@@ -323,21 +323,18 @@ class Manager : public RFModule, public managerTUG_IDL
 
         if (ok_nav)
         {
-            if(starting_pose.size()>0)
+            cmd.clear();
+            rep.clear();
+            cmd.addString("go_to_wait");
+            cmd.addDouble(starting_pose[0]);
+            cmd.addDouble(starting_pose[1]);
+            cmd.addDouble(starting_pose[2]);
+            if (navigationPort.write(cmd,rep))
             {
-                cmd.clear();
-                rep.clear();
-                cmd.addString("go_to_wait");
-                cmd.addDouble(starting_pose[0]);
-                cmd.addDouble(starting_pose[1]);
-                cmd.addDouble(starting_pose[2]);
-                if (navigationPort.write(cmd,rep))
+                if (rep.get(0).asVocab()==ok)
                 {
-                    if (rep.get(0).asVocab()==ok)
-                    {
-                        yInfo()<<"Back to initial position";
-                        ret=true;
-                    }
+                    yInfo()<<"Back to initial position";
+                    ret=true;
                 }
             }
         }
@@ -366,16 +363,15 @@ class Manager : public RFModule, public managerTUG_IDL
                     {
                         cmd.clear();
                         rep.clear();
-                        cmd.addString("get_state");
+                        cmd.addString("go_to_wait");
+                        cmd.addDouble(starting_pose[0]);
+                        cmd.addDouble(starting_pose[1]);
+                        cmd.addDouble(starting_pose[2]);
                         if (navigationPort.write(cmd,rep))
                         {
-                            Property robotState(rep.get(0).toString().c_str());
-                            if (Bottle *loc=robotState.find("robot-location").asList())
+                            if (rep.get(0).asVocab()==ok)
                             {
-                                starting_pose.resize(3);
-                                starting_pose[0]=loc->get(0).asDouble();
-                                starting_pose[1]=loc->get(1).asDouble();
-                                starting_pose[2]=loc->get(2).asDouble();
+                                yInfo()<<"Going to starting position";
                                 ret=true;
                             }
                         }
@@ -429,21 +425,18 @@ class Manager : public RFModule, public managerTUG_IDL
 
         if (ok_nav)
         {
-            if(starting_pose.size()>0)
+            cmd.clear();
+            rep.clear();
+            cmd.addString("go_to_wait");
+            cmd.addDouble(starting_pose[0]);
+            cmd.addDouble(starting_pose[1]);
+            cmd.addDouble(starting_pose[2]);
+            if (navigationPort.write(cmd,rep))
             {
-                cmd.clear();
-                rep.clear();
-                cmd.addString("go_to_wait");
-                cmd.addDouble(starting_pose[0]);
-                cmd.addDouble(starting_pose[1]);
-                cmd.addDouble(starting_pose[2]);
-                if (navigationPort.write(cmd,rep))
+                if (rep.get(0).asVocab()==ok)
                 {
-                    if (rep.get(0).asVocab()==ok)
-                    {
-                        yInfo()<<"Back to initial position";
-                        ret=true;
-                    }
+                    yInfo()<<"Back to initial position";
+                    ret=true;
                 }
             }
         }
@@ -459,8 +452,20 @@ class Manager : public RFModule, public managerTUG_IDL
         module_name=rf.check("name",Value("managerTUG")).asString();
         period=rf.check("period",Value(0.1)).asDouble();
         speak_file=rf.check("speak-file",Value("speak-it")).asString();
-        finish_line_thresh=rf.check("finish-line-thresh",Value(0.2)).asDouble();
-        standing_thresh=rf.check("standing-thresh",Value(0.3)).asDouble();
+        finish_line_thresh=rf.check("finish-line-thresh",Value(0.3)).asDouble();
+        standing_thresh=rf.check("standing-thresh",Value(0.2)).asDouble();
+        starting_pose={1.5,-3.0,110.0};
+        if(rf.check("starting-pose"))
+        {
+            if (const Bottle *sp=rf.find("starting-pose").asList())
+            {
+                size_t len=sp->size();
+                for (size_t i=0; i<len; i++)
+                {
+                    starting_pose[i]=sp->get(i).asDouble();
+                }
+            }
+        }
 
         this->setName(module_name.c_str());
 

--- a/modules/managerTUG/src/main.cpp
+++ b/modules/managerTUG/src/main.cpp
@@ -281,27 +281,30 @@ class Manager : public RFModule, public managerTUG_IDL
         cmd.addString("is_following");
         if (attentionPort.write(cmd,rep))
         {
-            if (Bottle *corB=rep.get(4).asList())
+            if (!rep.get(0).asString().empty())
             {
-                Vector coronal(3);
-                coronal[0]=corB->get(0).asDouble();
-                coronal[1]=corB->get(1).asDouble();
-                coronal[2]=corB->get(2).asDouble();
-
-                double x=(finishline_pose[0]-startline_pose[0])/2.0;
-                double y=finishline_pose[1]+0.5;
-                double theta=(180/M_PI)*atan2(-coronal[1],-coronal[0]);
-                cmd.clear();
-                rep.clear();
-                cmd.addString("go_to_wait");
-                cmd.addDouble(x);
-                cmd.addDouble(y);
-                cmd.addDouble(theta);
-                if (navigationPort.write(cmd,rep))
+                if (Bottle *corB=rep.get(4).asList())
                 {
-                    if (rep.get(0).asVocab()==ok)
+                    Vector coronal(3);
+                    coronal[0]=corB->get(0).asDouble();
+                    coronal[1]=corB->get(1).asDouble();
+                    coronal[2]=corB->get(2).asDouble();
+
+                    double x=(finishline_pose[0]-startline_pose[0])/2.0;
+                    double y=finishline_pose[1]+0.5;
+                    double theta=(180/M_PI)*atan2(-coronal[1],-coronal[0]);
+                    cmd.clear();
+                    rep.clear();
+                    cmd.addString("go_to_wait");
+                    cmd.addDouble(x);
+                    cmd.addDouble(y);
+                    cmd.addDouble(theta);
+                    if (navigationPort.write(cmd,rep))
                     {
-                        yInfo()<<"Back to initial position";
+                        if (rep.get(0).asVocab()==ok)
+                        {
+                            yInfo()<<"Back to initial position";
+                        }
                     }
                 }
             }

--- a/modules/motionAnalyzer/include/Manager.h
+++ b/modules/motionAnalyzer/include/Manager.h
@@ -41,7 +41,6 @@ class Manager : public yarp::os::RFModule,
     yarp::os::RpcClient dtwPort;
     yarp::os::RpcClient actionPort;
     yarp::os::BufferedPort<yarp::os::Bottle> scopePort;
-    yarp::os::BufferedPort<yarp::os::Property> gazePort;
 
     yarp::os::ResourceFinder *rf;
 
@@ -59,7 +58,6 @@ class Manager : public yarp::os::RFModule,
     Exercise* curr_exercise;
     std::vector<Processor*> processors;
     const Metric* curr_metric;
-    yarp::sig::Matrix gaze_frame;
 
     double tstart;
     double tstart_session;
@@ -103,7 +101,6 @@ class Manager : public yarp::os::RFModule,
     bool isSitting(const double standing_thresh) override;
     bool hasCrossedFinishLine(const double finishline_thresh) override;
     bool setLinePose(const std::vector<double> &line_pose) override;
-    bool set_world_frame(const yarp::sig::Matrix &world_frame) override;
 
     bool writeStructToMat(const std::string& name, const std::vector< std::vector< std::pair<std::string,yarp::sig::Vector> > >& keypoints_skel, mat_t *matfp);
     bool writeStructToMat(const std::string& name, const Exercise *ex, mat_t *matfp);

--- a/modules/motionAnalyzer/include/Manager.h
+++ b/modules/motionAnalyzer/include/Manager.h
@@ -80,6 +80,7 @@ class Manager : public yarp::os::RFModule,
     iCub::ctrl::AWLinEstimator *lin_est_shoulder;
     double shoulder_center_height_vel;
     std::vector<double> line_pose;
+    yarp::sig::Matrix world_frame;
 
     bool loadMotionList(yarp::os::ResourceFinder &rf);
     bool loadExercise(const std::string &exercise_tag) override;
@@ -102,6 +103,7 @@ class Manager : public yarp::os::RFModule,
     bool isSitting(const double standing_thresh) override;
     bool hasCrossedFinishLine(const double finishline_thresh) override;
     bool setLinePose(const std::vector<double> &line_pose) override;
+    bool set_world_frame(const yarp::sig::Matrix &world_frame) override;
 
     bool writeStructToMat(const std::string& name, const std::vector< std::vector< std::pair<std::string,yarp::sig::Vector> > >& keypoints_skel, mat_t *matfp);
     bool writeStructToMat(const std::string& name, const Exercise *ex, mat_t *matfp);

--- a/modules/motionAnalyzer/include/Processor.h
+++ b/modules/motionAnalyzer/include/Processor.h
@@ -36,7 +36,7 @@ class Processor
 
 protected:
     assistive_rehab::SkeletonStd curr_skeleton,first_skeleton;
-    yarp::sig::Matrix inv_reference_system,gaze_frame;
+    yarp::sig::Matrix curr_frame;
     yarp::sig::Vector plane_normal;
     double t0;
 
@@ -44,9 +44,9 @@ public:
     Processor();
     virtual ~Processor() {;}
     void setInitialConf(assistive_rehab::SkeletonStd &skeleton_, yarp::sig::Matrix &T);
-    void update(assistive_rehab::SkeletonStd& curr_skeleton_, const yarp::sig::Matrix &gaze_frame);
+    void update(assistive_rehab::SkeletonStd& curr_skeleton_);
     yarp::sig::Vector projectOnPlane(const yarp::sig::Vector &v,const yarp::sig::Vector &plane);
-    yarp::sig::Vector getKeypointRoot(const std::string &tag);
+    yarp::sig::Vector toCurrFrame(const std::string &tag);
     void stop();
 
     yarp::sig::Vector getPlaneNormal() const { return plane_normal; }

--- a/modules/motionAnalyzer/src/Manager.cpp
+++ b/modules/motionAnalyzer/src/Manager.cpp
@@ -856,16 +856,24 @@ bool Manager::isSitting(const double standing_thresh)
 }
 
 /********************************************************/
+bool Manager::set_world_frame(const Matrix &world_frame)
+{
+    lock_guard<mutex> lg(mtx);
+    this->world_frame=world_frame;
+    return true;
+}
+
+/********************************************************/
 bool Manager::hasCrossedFinishLine(const double finishline_thresh)
 {
     lock_guard<mutex> lg(mtx);
     Vector foot_right=skeletonIn[KeyPointTag::ankle_right]->getPoint();
     Vector foot_left=skeletonIn[KeyPointTag::ankle_left]->getPoint();
     foot_right.push_back(1.0);
-    foot_right=gaze_frame*foot_right;
+    foot_right=(world_frame*gaze_frame)*foot_right;
     foot_right.pop_back();
     foot_left.push_back(1.0);
-    foot_left=gaze_frame*foot_left;
+    foot_left=(world_frame*gaze_frame)*foot_left;
     foot_left.pop_back();
 
     Vector lp_root(3);

--- a/modules/motionAnalyzer/src/Manager.cpp
+++ b/modules/motionAnalyzer/src/Manager.cpp
@@ -876,10 +876,10 @@ bool Manager::hasCrossedFinishLine(const double finishline_thresh)
     foot_left=(world_frame*gaze_frame)*foot_left;
     foot_left.pop_back();
 
-    Vector lp_root(3);
-    lp_root[0]=line_pose[0];
-    lp_root[1]=line_pose[1];
-    lp_root[2]=line_pose[2];
+    Vector lp_world(3);
+    lp_world[0]=line_pose[0];
+    lp_world[1]=line_pose[1];
+    lp_world[2]=line_pose[2];
 
     Vector line_ori(4);
     line_ori[0]=line_pose[3];
@@ -890,10 +890,10 @@ bool Manager::hasCrossedFinishLine(const double finishline_thresh)
     Vector line_x=lOri.getCol(0);
     line_x.pop_back();
 
-    Vector fr_lp=lp_root-foot_right;
-    Vector fl_lp=lp_root-foot_left;
-    Vector pline=lp_root+line_x;
-    Vector v1=lp_root-pline;
+    Vector fr_lp=lp_world-foot_right;
+    Vector fl_lp=lp_world-foot_left;
+    Vector pline=lp_world+line_x;
+    Vector v1=lp_world-pline;
     double dist_fr_line=norm(cross(v1,fr_lp))/norm(v1);
     double dist_fl_line=norm(cross(v1,fl_lp))/norm(v1);
     yInfo()<<"dist foot right line"<<dist_fr_line;

--- a/modules/motionAnalyzer/src/idl.thrift
+++ b/modules/motionAnalyzer/src/idl.thrift
@@ -149,12 +149,4 @@ service motionAnalyzer_IDL
    */
    bool setLinePose(1:list<double> line_pose);
 
-   /**
-   * Set world frame from the start line.
-   * @param world_frame 4x4 transformation matrix from robot root to start line.
-   * @return true/false on success/failure.
-   */
-   bool set_world_frame(1:Matrix world_frame);
-
-
 }

--- a/modules/motionAnalyzer/src/idl.thrift
+++ b/modules/motionAnalyzer/src/idl.thrift
@@ -10,6 +10,12 @@
 * IDL Interface to Motion Analyzer services.
 */
 
+struct Matrix { }
+(
+   yarp.name="yarp::sig::Matrix"
+   yarp.includefile="yarp/sig/Matrix.h"
+)
+
 service motionAnalyzer_IDL
 {
 
@@ -142,5 +148,13 @@ service motionAnalyzer_IDL
    * @return true/false on success/failure.
    */
    bool setLinePose(1:list<double> line_pose);
+
+   /**
+   * Set world frame from the start line.
+   * @param world_frame 4x4 transformation matrix from robot root to start line.
+   * @return true/false on success/failure.
+   */
+   bool set_world_frame(1:Matrix world_frame);
+
 
 }


### PR DESCRIPTION
This PR integrates navigation into the TUG.
Before starting the TUG, a localization phase described below is required.

**Localization**
The robot has to localize itself with respect to the world, which is set from the start-line. For doing so, we bring the robot through the joystick to a spot where the line to detect is clearly visible (we adjust the head pitch through the motor gui). Start-line should be detected first, as finish-line is expressed with respect to it.
Then we connect to `/lineDetector/cmd:rpc` and send the commands:
- `detect start-line`: to detect the start-line;
- `detect finish-line`: to detect the finish-line.

Both commands are blocking, waiting until a _good_ estimate of the line is provided. Line is considered good when the median filter has enough samples for the estimation and, when so, the detected is added to the `opc`. 
To retrieve lines' poses with respect to the world, we can use the commands `get_line_pose start-line` and `get_line_pose finish-line` (the start line will be at 0.0, 0.0, 0.0).

**TUG**
After the localization phase, we bring the robot to an initial spot facing the chair and give a `start` to `/managerTUG/cmd:rpc`. The robot navigates as follows:
- the robot explains the test and navigates to the finish line;
- during the exercise, the robot tracks the skeleton while navigating on a straight path;
- when the exercise finishes, the robot goes back to the initial position.