### PR TITLE
Generate skeletons wrt world frame

### DIFF
--- a/modules/robotSkeletonPublisher/CMakeLists.txt
+++ b/modules/robotSkeletonPublisher/CMakeLists.txt
@@ -12,5 +12,6 @@ source_group("IDL Files" FILES src/idl.thrift)
 source_group("DOC Files" FILES ${doc_files})
 
 add_executable(${PROJECT_NAME} src/main.cpp src/idl.thrift ${IDL_GEN_FILES} ${doc_files})
+target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
 target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} iKin CER::cer_kinematics AssistiveRehab)
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/modules/robotSkeletonPublisher/robotSkeletonPublisher.xml
+++ b/modules/robotSkeletonPublisher/robotSkeletonPublisher.xml
@@ -11,6 +11,8 @@
   <description-long>
    This module connects to robot's state ports to retrieve the joints and then uses such information to compute the 
    3D configuration of the limbs. The resulting skeleton is sent to the viewer and to the OPC.
+   The 3D info are expressed in the world frame if the navigation state is provided; the root becomes the depth_center
+   frame otherwise.
   </description-long>
 
   <arguments>
@@ -26,6 +28,13 @@
   </authors>
 
   <data>
+      <input>
+          <type>Property</type>
+          <port>/robotSkeletonPublisher/nav:i</port>
+          <description>
+            Receives the navigation status broadcast.
+          </description>
+      </input>
       <output>
           <type>Bottle</type>
           <port>/robotSkeletonPublisher/viewer:o</port>

--- a/modules/skeletonRetriever/skeletonRetriever.xml
+++ b/modules/skeletonRetriever/skeletonRetriever.xml
@@ -56,6 +56,20 @@
             Receives stream of camera depth images.
           </description>
       </input>
+      <input>
+          <type>Property</type>
+          <port>/skeletonRetriever/nav:i</port>
+          <description>
+            Receives the navigation status broadcast.
+          </description>
+      </input>
+      <input>
+          <type>Property</type>
+          <port>/skeletonRetriever/gaze:i</port>
+          <description>
+            Receives the gaze status broadcast.
+          </description>
+      </input>
       <output>
           <type>rpc</type>
           <port>/skeletonRetriever/opc:rpc</port>

--- a/modules/skeletonScaler/src/main.cpp
+++ b/modules/skeletonScaler/src/main.cpp
@@ -259,29 +259,33 @@ class Scaler : public RFModule
     /****************************************************************/
     bool rotateCam(const Vector& camerapos,const Vector& focalpoint)
     {
-        Bottle cmd,rep;
-        cmd.addString("set_camera");
-        Bottle &content1 = cmd.addList();
-        content1.addString("position");
-        Bottle &position = content1.addList();
-        position.addDouble(camerapos[0]);
-        position.addDouble(camerapos[1]);
-        position.addDouble(camerapos[2]);
-        Bottle &content2 = cmd.addList();
-        content2.addString("focalpoint");
-        Bottle &fp = content2.addList();
-        fp.addDouble(focalpoint[0]);
-        fp.addDouble(focalpoint[1]);
-        fp.addDouble(focalpoint[2]);
-
-        yInfo() << cmd.toString();
-        if(rpcViewerPort.write(cmd,rep))
+        bool ret_pos=false;
         {
-            if(rep.get(0).asVocab()==Vocab::encode("ack"))
-                return true;
+            Bottle cmd,rep;
+            cmd.addString("set_camera_position");
+            cmd.addDouble(camerapos[0]);
+            cmd.addDouble(camerapos[1]);
+            cmd.addDouble(camerapos[2]);
+            if(rpcViewerPort.write(cmd,rep))
+            {
+                ret_pos=rep.get(0).asVocab()==Vocab::encode("ack");
+            }
         }
 
-        return false;
+        bool ret_foc=false;
+        {
+            Bottle cmd,rep;
+            cmd.addString("set_camera_focalpoint");
+            cmd.addDouble(focalpoint[0]);
+            cmd.addDouble(focalpoint[1]);
+            cmd.addDouble(focalpoint[2]);
+            if(rpcViewerPort.write(cmd,rep))
+            {
+                ret_foc=rep.get(0).asVocab()==Vocab::encode("ack");
+            }
+        }
+
+        return (ret_pos && ret_foc);
     }
 
     /****************************************************************/

--- a/modules/skeletonViewer/CMakeLists.txt
+++ b/modules/skeletonViewer/CMakeLists.txt
@@ -3,13 +3,16 @@
 # Authors: Ugo Pattacini <ugo.pattacini@iit.it>
 
 project(skeletonViewer)
-
 set(doc_files ${PROJECT_NAME}.xml)
 
+yarp_add_idl(IDL_GEN_FILES src/idl.thrift)
+
+source_group("IDL Files" FILES src/idl.thrift)
 source_group("DOC Files" FILES ${doc_files})
 
 include(${VTK_USE_FILE})
-add_executable(${PROJECT_NAME} main.cpp ${doc_files})
+add_executable(${PROJECT_NAME} src/main.cpp src/idl.thrift ${IDL_GEN_FILES} ${doc_files})
+target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
 target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ${VTK_LIBRARIES} AssistiveRehab)
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/modules/skeletonViewer/skeletonViewer.xml
+++ b/modules/skeletonViewer/skeletonViewer.xml
@@ -35,13 +35,15 @@
             Receives 3D skeletons to visualize.
           </description>
       </input>
-      <input>
-           <type>rpc</type>
-           <port>/skeletonViewer:rpc</port>
-           <description>Receives the following commands and provides replies: (notation: "." identifies a string)
-           -# <b>set camera options</b> <i>"set_camera" ("position" pos_list) ("focalpoint" focal_list) ("viewup" view_list)</i>:set camera options for visualization. pos_list the position of the camera in world coordinates (set to (0.0,0.0,1.0) if not provided). focal_list the focal point of the camera in world coordinates (set to (0.0,0.0,0.0) if not provided). view_list view up direction for the camera (set to (0.0,1.0,0.0) if not provided).
-           </description>
-       </input>
   </data>
+
+  <services>
+    <server>
+      <type>skeletonViewer_IDL</type>
+      <idl>idl.thrift</idl>
+      <port>/skeletonViewer:rpc</port>
+      <description>service port</description>
+    </server>
+  </services>
 
 </module>

--- a/modules/skeletonViewer/src/idl.thrift
+++ b/modules/skeletonViewer/src/idl.thrift
@@ -1,0 +1,72 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+/**
+ * @file idl.thrift
+ * @authors: Ugo Pattacini <ugo.pattacini@iit.it>
+ */
+
+/**
+ * skeletonViewer_IDL
+ *
+ * IDL Interface to skeletonViewer RPC services.
+ */
+service skeletonViewer_IDL
+{
+   /**
+    * Set the camera position in world coordinates.
+    * @param x is the x-coordinate (meters).
+    * @param y is the y-coordinate (meters).
+    * @param z is the z-coordinate (meters).
+    * @return true/false on success/failure.
+    */
+   bool set_camera_position(1:double x, 2:double y, 3:double z);
+
+   /**
+    * Set the camera focal point in world coordinates.
+    * @param x is the x-coordinate (meters).
+    * @param y is the y-coordinate (meters).
+    * @param z is the z-coordinate (meters).
+    * @return true/false on success/failure.
+    */
+   bool set_camera_focalpoint(1:double x, 2:double y, 3:double z);
+
+   /**
+    * Set the camera view up direction in world coordinates.
+    * @param x is the x-coordinate (meters).
+    * @param y is the y-coordinate (meters).
+    * @param z is the z-coordinate (meters).
+    * @return true/false on success/failure.
+    */
+   bool set_camera_viewup(1:double x, 2:double y, 3:double z);
+
+   /**
+    * Create a line.
+    * @param name is the name of the line.
+    * @param x0 the x-coordinate of the line origin (meters).
+    * @param y0 the y-coordinate of the line origin (meters).
+    * @param z0 the z-coordinate of the line origin (meters).
+    * @param x1 the x-coordinate of the line end (meters).
+    * @param y1 the y-coordinate of the line end (meters).
+    * @param z1 the z-coordinate of the line end (meters).
+    * @param r is the red channel of the line color [0,1].
+    * @param g is the green channel of the line color [0,1].
+    * @param b is the blue channel of the line color [0,1].
+    * @return true/false on success/failure.
+    */
+   bool create_line(1:string name,
+                    2:double x0, 3:double y0, 4:double z0,
+		    5:double x1, 6:double y1, 7:double z1,
+		    8:double r, 9:double g, 10:double b);
+
+   /**
+    * Delete a line.
+    * @param name is the name of the line to delete.
+    * @return true/false on success/failure.
+    */
+   bool delete_line(1:string name);
+}


### PR DESCRIPTION
This PR introduces the following options:
- `skeletonRetriever` can now stream skeletons in the world frame, iff it gets connected to `navController`'s state and `cer_gaze-controller`'s state.
- `robotSkeletonPublisher` can now stream robot's skeleton in the world frame, iff it gets connected to `navController`'s state.
- `skeletonViewer` is now thrifted (look up the available services) and can display lines on request. Because of this, `skeletonScaler` has been upgraded accordingly in order to talk to the viewer correctly.

| Tests demonstrated to be successful |
|:---:|
| ![skeletonRetriever](https://user-images.githubusercontent.com/3738070/67315992-f970b480-f507-11e9-87df-171b58b265f0.gif) |
| ![robotStatePublisher](https://user-images.githubusercontent.com/3738070/67316026-0392b300-f508-11e9-9ef7-d154d7aaaf86.gif) |

@vvasco keep note that the skeletons are streamed out in this modality using the `setTransformation` utility of the library. Further, given that all the transformations are now handled here, you ought to modify the existing application code accordingly.
