### PR TITLE
Integrate speech in TUG

### DIFF
--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -341,4 +341,9 @@
         <protocol>fast_tcp</protocol>
     </connection>
 
+    <connection>
+        <from>/googleSpeechProcess/result:o</from>
+        <to>/managerTUG/speech-interp:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
 </application>

--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -334,7 +334,6 @@
         <to>/iSpeak/rpc</to>
         <protocol>fast_tcp</protocol>
     </connection>
-
     <connection>
         <from>/managerTUG/navigation:rpc</from>
         <to>/navController/rpc</to>
@@ -342,8 +341,14 @@
     </connection>
 
     <connection>
+        <from>/googleSpeech/question:o</from>
+        <to>/managerTUG/question:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
         <from>/googleSpeechProcess/result:o</from>
-        <to>/managerTUG/speech-interp:i</to>
+        <to>/managerTUG/answer:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
 </application>

--- a/modules/managerTUG/app/conf/speak-en.ini
+++ b/modules/managerTUG/app/conf/speak-en.ini
@@ -1,5 +1,5 @@
 [general]
-num-sections    24
+num-sections    27
 
 [section-0]
 key             "ouch"
@@ -23,7 +23,7 @@ value           "Great!"
 
 [section-5]
 key             "explain"
-value           "Let me explain how the test works. Please seat on that chair. When I will give you the start, you will have to stand up, walk at your normal speed, cross the line on the floor, go back and seat down again."
+value           "Let me explain how the test works. Please seat on that chair."
 
 [section-6]
 key             "start"
@@ -96,3 +96,15 @@ value           "Everything clear?"
 [section-23]
 key             "line"
 value           "This is the line that you have to cross."
+
+[section-24]
+key             "explain-walk"
+value           "When I will give you the start, you will have to stand up and walk at your normal speed"
+
+[section-25]
+key             "explain-line"
+value           "Then you will have to cross this line on the floor."
+
+[section-26]
+key             "explain-end"
+value           "Finally, you will have to go back and seat down again."

--- a/modules/managerTUG/app/conf/speak-it.ini
+++ b/modules/managerTUG/app/conf/speak-it.ini
@@ -1,5 +1,5 @@
 [general]
-num-sections    24
+num-sections    27
 
 [section-0]
 key             "ouch"
@@ -22,8 +22,8 @@ key             "accepted"
 value           "Fantastico!"
 
 [section-5]
-key             "explain"
-value           "Ora ti spiego come funziona il test. Quando ti darò il via, dovrai alzarti, camminare alla tua normale andatura, superare la linea sul pavimento, tornare indietro e risederti."
+key             "explain-start"
+value           "Ora ti spiego come funziona il test."
 
 [section-6]
 key             "start"
@@ -96,3 +96,15 @@ value           "Tutto chiaro?"
 [section-23]
 key             "line"
 value           "Questa è la linea che dovrai superare."
+
+[section-24]
+key             "explain-walk"
+value           "Quando ti darò il via, dovrai alzarti e camminare alla tua normale andatura."
+
+[section-25]
+key             "explain-line"
+value           "Poi dovrai superare questa linea sul pavimento."
+
+[section-26]
+key             "explain-end"
+value           "Infine dovrai tornare indietro e risederti."

--- a/modules/managerTUG/src/main.cpp
+++ b/modules/managerTUG/src/main.cpp
@@ -237,7 +237,7 @@ class Manager : public RFModule, public managerTUG_IDL
 
     const int ok=Vocab::encode("ok");
     const int fail=Vocab::encode("fail");
-    enum class State { frozen, stopped, idle, seek_skeleton, follow, engaged, explain, reach_line, starting, assess_standing, assess_crossing, line_crossed, not_passed, finished } state;
+    enum class State { assess_standing, assess_crossing, line_crossed, frozen, stopped, idle, seek_skeleton, follow, engaged, explain, reach_line, starting, not_passed, finished } state;
     State prev_state;
     string tag;
     double t0,tstart,t;
@@ -1069,8 +1069,8 @@ class Manager : public RFModule, public managerTUG_IDL
             Bottle cmd,rep;
             cmd.addString("stop");
             analyzerPort.write(cmd,rep);
-            speak("assess-high",false,p);
-            speak("greetings",false);
+            speak("assess-high",true,p);
+            speak("greetings",true);
             disengage();
         }
 
@@ -1079,9 +1079,9 @@ class Manager : public RFModule, public managerTUG_IDL
             Bottle cmd,rep;
             cmd.addString("stop");
             analyzerPort.write(cmd,rep);
-            speak("end",false);
-            speak("assess-low",false);
-            speak("greetings",false);
+            speak("end",true);
+            speak("assess-low",true);
+            speak("greetings",true);
             disengage();
         }
 

--- a/modules/motionAnalyzer/include/Manager.h
+++ b/modules/motionAnalyzer/include/Manager.h
@@ -64,7 +64,7 @@ class Manager : public yarp::os::RFModule,
     double tend_session;
     bool finishedSession;
 
-    bool starting;
+    bool starting,frozen;
 
     std::string skel_tag,template_tag;
     bool use_robot_template,robot_skeleton_mirror;
@@ -101,6 +101,7 @@ class Manager : public yarp::os::RFModule,
     bool isSitting(const double standing_thresh) override;
     bool hasCrossedFinishLine(const double finishline_thresh) override;
     bool setLinePose(const std::vector<double> &line_pose) override;
+    bool freeze() override;
 
     bool writeStructToMat(const std::string& name, const std::vector< std::vector< std::pair<std::string,yarp::sig::Vector> > >& keypoints_skel, mat_t *matfp);
     bool writeStructToMat(const std::string& name, const Exercise *ex, mat_t *matfp);

--- a/modules/motionAnalyzer/src/idl.thrift
+++ b/modules/motionAnalyzer/src/idl.thrift
@@ -149,4 +149,10 @@ service motionAnalyzer_IDL
    */
    bool setLinePose(1:list<double> line_pose);
 
+   /**
+   * Freeze module.
+   * @return true/false on success/failure.
+   */
+   bool freeze();
+
 }


### PR DESCRIPTION
This PR integrates `managerTUG` with the speech modules. 
The logic is the following: 
- whenever a **question** is received by providing a `start` command to `/googleSpeech/rpc`, `googleSpeech` sends a trigger to `managerTUG`;
- the state is frozen until an **answer** is received by `googleSpeechProcess` (note: the motion evaluation states are not frozen, as the assessment should go on also during a question).

The scenarios can be the following:
- if the robot receives a question while navigating to the finish line, the robot stops, answers the question and navigates again to the line;
- if the robot receives a question while speaking, the robot finishes the current sentence and answers the question (the sentences for explaining the exercise are short enough to make the interaction "natural");
- if the answer provided by `googleSpeechProcess` is empty (this might happen if the question is not understood or the sentence analysis falls in a case which we are not currently managing), the robot says that the question was not understood.
