### PR TITLE
Improved lines handling

### DIFF
--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -102,6 +102,18 @@
     </module>
 
     <module>
+        <name>ctpService</name>
+        <parameters>--robot cer --part right_arm</parameters>
+        <node>r1-console-linux</node>
+    </module>
+
+    <module>
+        <name>ctpService</name>
+        <parameters>--robot cer --part left_arm</parameters>
+        <node>r1-console-linux</node>
+    </module>
+
+    <module>
         <name>yarpview</name>
         <parameters>--name /viewer/depth --x 10 --y 40 --p 50 --compact</parameters>
         <node>r1-display-linux</node>
@@ -334,6 +346,7 @@
         <to>/iSpeak/rpc</to>
         <protocol>fast_tcp</protocol>
     </connection>
+
     <connection>
         <from>/managerTUG/navigation:rpc</from>
         <to>/navController/rpc</to>
@@ -349,6 +362,18 @@
     <connection>
         <from>/googleSpeechProcess/result:o</from>
         <to>/managerTUG/answer:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/left_arm:rpc</from>
+        <to>/ctpservice/left_arm/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/right_arm:rpc</from>
+        <to>/ctpservice/right_arm/rpc</to>
         <protocol>fast_tcp</protocol>
     </connection>
 </application>

--- a/modules/lineDetector/src/idl.thrift
+++ b/modules/lineDetector/src/idl.thrift
@@ -45,15 +45,25 @@ service lineDetector_IDL
     Vector get_line_pose(1:string line);
 
    /**
-    * Reset lines.
+    * Delete lines from opc and skeletonViewer.
     * @return true/false on success/failure.
     */
     bool reset();
 
    /**
-    * Stop detection.
+    * Update robot's odometry with respect to specified line.
+    * @param line_tag string indicating line with respect to calibrate, start-line or finish-line.
+    * @param theta angle-coordinate to reach the specified line (degrees).
     * @return true/false on success/failure.
     */
-    bool stop();
+    bool update_odometry(1:string line_tag, 2:double theta);
+
+   /**
+    * Navigate to the specified line.
+    * @param line_tag string indicating line with respect to calibrate, start-line or finish-line.
+    * @param theta angle-coordinate to reach the specified line (degrees).
+    * @return true/false on success/failure.
+    */
+    bool go_to_line(1:string line_tag, 2:double theta);
 
 }

--- a/modules/managerTUG/app/conf/config-en.ini
+++ b/modules/managerTUG/app/conf/config-en.ini
@@ -4,3 +4,7 @@ speak-file                speak-en.ini
 finish-line-thresh        0.3
 standing-thresh           0.2
 starting-pose             (1.5 -3.0 110.0)
+pointing-time             3.0
+pointing-home             (-10.0 20.0 -10.0 35.0 0.0 0.030 0.0 0.0) 
+pointing-start            (70.0 12.0 -10.0 10.0 0.0 0.050 0.0 0.0)  
+pointing-finish           (35.0 12.0 -10.0 10.0 0.0 0.050 0.0 0.0)

--- a/modules/managerTUG/app/conf/config-it.ini
+++ b/modules/managerTUG/app/conf/config-it.ini
@@ -4,3 +4,7 @@ speak-file                speak-it.ini
 finish-line-thresh        0.3
 standing-thresh           0.2
 starting-pose             (1.5 -3.0 110.0)
+pointing-time             3.0
+pointing-home             (-10.0 20.0 -10.0 35.0 0.0 0.030 0.0 0.0) 
+pointing-start            (70.0 12.0 -10.0 10.0 0.0 0.050 0.0 0.0)  
+pointing-finish           (35.0 12.0 -10.0 10.0 0.0 0.050 0.0 0.0)


### PR DESCRIPTION
This PR improves the way lines are handled. 
- lines have to be visually detected only once, when starting the demo;
- if a `reset` command is given, lines are removed from the opc and from the viewer and have to be visually detected again, through the `detect` command;
- we can calibrate the robot by bringing it to the start or finish line and using the command `update_odometry`.