### PR TITLE
Remove any reference to boost from actionRecognizer

### DIFF
--- a/modules/actionRecognizer/src/main.cpp
+++ b/modules/actionRecognizer/src/main.cpp
@@ -18,7 +18,6 @@
 #include <yarp/os/all.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/math/Math.h>
-#include <boost/algorithm/string.hpp>
 #include <tensorflow/core/public/session.h>
 #include <tensorflow/core/protobuf/meta_graph.pb.h>
 #include <tensorflow/cc/client/client_session.h>


### PR DESCRIPTION
Just removing what I think is a leftover since we don't rely on boost AFAIK.
Realized because of a failed CI.

@vvasco am I right?