### PR TITLE
humanStructure overhaul 

### DIFF
--- a/modules/humanStructure/CMakeLists.txt
+++ b/modules/humanStructure/CMakeLists.txt
@@ -15,9 +15,10 @@ endforeach()
 set(doc_files ${PROJECT_NAME}.xml)
 source_group("DOC Files" FILES ${doc_files})
 
-include_directories(${OpenCV_INCLUDE_DIRS})
+target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
 
 add_executable(${PROJECT_NAME} main.cpp ${doc_files} ${IDL_GEN_FILES})
+target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
 target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ${OpenCV_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 

--- a/modules/humanStructure/CMakeLists.txt
+++ b/modules/humanStructure/CMakeLists.txt
@@ -1,11 +1,19 @@
-# Copyright: (C) 2018 iCub Facility - Istituto Italiano di Tecnologia
+# Copyright: (C) 2019 iCub Facility - Istituto Italiano di Tecnologia
 # Authors: Vadim Tikhanoff
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
 project(humanStructure)
 
+message("YARP_LIBRARIES = ${YARP_LIBRARIES}")
+foreach(target ${YARP_LIBRARIES})
+    get_property(x TARGET ${target} PROPERTY INTERFACE_LINK_LIBRARIES)
+    message("    ${target} -> ${x}")
+endforeach()
+
 set(doc_files ${PROJECT_NAME}.xml)
 source_group("DOC Files" FILES ${doc_files})
+
+include_directories(${OpenCV_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME} main.cpp ${doc_files})
 target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ${OpenCV_LIBRARIES})

--- a/modules/humanStructure/CMakeLists.txt
+++ b/modules/humanStructure/CMakeLists.txt
@@ -15,8 +15,6 @@ endforeach()
 set(doc_files ${PROJECT_NAME}.xml)
 source_group("DOC Files" FILES ${doc_files})
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
-
 add_executable(${PROJECT_NAME} main.cpp ${doc_files} ${IDL_GEN_FILES})
 target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
 target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ${OpenCV_LIBRARIES})

--- a/modules/humanStructure/CMakeLists.txt
+++ b/modules/humanStructure/CMakeLists.txt
@@ -7,7 +7,7 @@ project(humanStructure)
 message(STATUS "YARP_LIBRARIES = ${YARP_LIBRARIES}")
 foreach(target ${YARP_LIBRARIES})
     get_property(x TARGET ${target} PROPERTY INTERFACE_LINK_LIBRARIES)
-    message("    ${target} -> ${x}")
+    message(STATUS "    ${target} -> ${x}")
 endforeach()
 
 set(doc_files ${PROJECT_NAME}.xml)

--- a/modules/humanStructure/CMakeLists.txt
+++ b/modules/humanStructure/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 project(humanStructure)
 
+yarp_add_idl(IDL_GEN_FILES ${PROJECT_NAME}.thrift)
+
 message(STATUS "YARP_LIBRARIES = ${YARP_LIBRARIES}")
 foreach(target ${YARP_LIBRARIES})
     get_property(x TARGET ${target} PROPERTY INTERFACE_LINK_LIBRARIES)
@@ -15,7 +17,7 @@ source_group("DOC Files" FILES ${doc_files})
 
 include_directories(${OpenCV_INCLUDE_DIRS})
 
-add_executable(${PROJECT_NAME} main.cpp ${doc_files})
+add_executable(${PROJECT_NAME} main.cpp ${doc_files} ${IDL_GEN_FILES})
 target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ${OpenCV_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 

--- a/modules/humanStructure/CMakeLists.txt
+++ b/modules/humanStructure/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 project(humanStructure)
 
-message("YARP_LIBRARIES = ${YARP_LIBRARIES}")
+message(STATUS "YARP_LIBRARIES = ${YARP_LIBRARIES}")
 foreach(target ${YARP_LIBRARIES})
     get_property(x TARGET ${target} PROPERTY INTERFACE_LINK_LIBRARIES)
     message("    ${target} -> ${x}")

--- a/modules/humanStructure/humanStructure.thrift
+++ b/modules/humanStructure/humanStructure.thrift
@@ -1,0 +1,32 @@
+# Copyright: (C) 2019 iCub Facility - Istituto Italiano di Tecnologia
+# Authors: Vadim Tikhanoff
+# CopyPolicy: Released under the terms of the GNU GPL v2.0.
+#
+# humanStructure.thrift
+
+/**
+* humanStructure_IDLServer
+*
+* IDL Interface to \ref human structure module.
+*/
+
+service humanStructure_IDLServer
+{
+    /**
+     * Set the threshold number for finding the arm.
+     * @return true/false on success/failure
+     */
+    bool setArmThresh(1:i32 threshold );
+    
+    /**
+     * Get threshold value for finding the arm.
+     * @return number of frames
+     */
+    i32 getArmThresh();
+
+    /**
+     * Quit the module.
+     * @return true/false on success/failure.
+     */
+    bool quit();
+}

--- a/modules/humanStructure/humanStructure.xml
+++ b/modules/humanStructure/humanStructure.xml
@@ -87,5 +87,14 @@
           </description>
       </output>
   </data>
+  
+  <services>
+    <server>
+      <type>humanStructure_IDLServer</type>
+      <idl>humanStructure.thrift</idl>
+      <port>/humanStructure/rpc</port>
+      <description>service port</description>
+    </server>
+  </services>
 
 </module>

--- a/modules/humanStructure/humanStructure.xml
+++ b/modules/humanStructure/humanStructure.xml
@@ -4,14 +4,13 @@
 <module>
   <name>humanStructure</name>
   <doxygen-group>humanStructure</doxygen-group>
-  <description>This module takes as input an image and 2D skeleton data and outputs sorted blobs around their faces.</description>
+  <description>This module takes as input an image and 2D skeleton data and outputs a series of data such as skeleton tracked, bounbing box around object of interest.</description>
   <copypolicy> Released under the terms of the BSD 3-Clause License.</copypolicy>
   <version>0.3.0</version>
 
   <description-long>
-   This module takes as input an image and 2D skeleton data from yarpOpenPose and outputs sorted blobs around their faces.
-   Skeleton data are used to define blobs, whose corners are extracted from right ear and left ear keypoints (if one of the two is not detected, the nose is used).
-   Only skeletons with valid nose keypoints are considered, to avoid sending backward oriented faces.
+   This module takes as input an image and 2D skeleton data from yarpOpenPose.
+   Skeleton data are used to get skeleton of interest (from arm lifted), send a trigger to the speech pipeline when lifting and lowering the arm. Get the bounding box of interest from the selected skeleton. 
    Detected blobs are finally sorted from left to right to avoid confusion in case of occlusion (yarpOpenPose outputs an unsorted list of 2D skeletons).
   </description-long>
 
@@ -38,11 +37,32 @@
             Receives the input image. To be connected to \yarpOpenPose\propag:o.
           </description>
       </input>
+      <input>
+          <type>ImageOfPixelFloat</type>
+          <port>/humanStructure/float:i</port>
+          <description>
+            Receives the float image. To be connected to \yarpOpenPose\float:o
+          </description>
+      </input>
       <output>
           <type>ImageOfPixelRgb</type>
           <port>/humanStructure/image:o</port>
           <description>
-            Streams out the input image with blobs around the detected faces.
+            Streams out the input image with blobs around the detected ROI.
+          </description>
+      </output>
+      <output>
+          <type>ImageOfPixelMono</type>
+          <port>/humanStructure/depth:o</port>
+          <description>
+            Streams out the depth image blobs around the detected ROI.
+          </description>
+      </output>
+      <output>
+          <type>ImageOfPixelMono</type>
+          <port>/humanStructure/segmented:o</port>
+          <description>
+            Streams out the segmented ROI.
           </description>
       </output>
       <output>
@@ -57,6 +77,13 @@
           <port>/humanStructure/blobs:o</port>
           <description>
             Streams out blobs' coordinates around detected faces as top left and bottom right corners.
+          </description>
+      </output>
+      <output>
+          <type>Bottle</type>
+          <port>/humanStructure/trigger:o</port>
+          <description>
+            Streams out the trigger for the speech pipeline.
           </description>
       </output>
   </data>

--- a/modules/humanStructure/main.cpp
+++ b/modules/humanStructure/main.cpp
@@ -312,7 +312,7 @@ public:
         yarp::sig::ImageOf<yarp::sig::PixelRgb> &outImage = imageOutPort.prepare();
         yarp::sig::ImageOf<yarp::sig::PixelMono> &outDepth = imageOutDepthPort.prepare();
         yarp::sig::ImageOf<yarp::sig::PixelMono> &outSegment = imageOutSegmentPort.prepare();
-        yarp::os::Bottle &triggerSpeech  = armPort.prepare();
+
 
         while (imageInPort.getInputCount() < 1 || imageInFloat.getInputCount() < 1 )
         {
@@ -760,7 +760,6 @@ public:
                     cv::addWeighted(overlayObject, opacity, out_cv, 1 - opacity, 0, out_cv);
                 }
                 //send arm trigger
-                triggerSpeech.clear();
                 if (index > -1 && isArmLifted==false)
                 {
                     yarp::os::Bottle cmd,rep;
@@ -775,8 +774,6 @@ public:
                     isArmLifted = false;
                     armPort.write(cmd,rep);
                 }
-                else
-                    triggerSpeech.clear();
             }
             else
                 followSkeletonIndex = -1;

--- a/modules/humanStructure/main.cpp
+++ b/modules/humanStructure/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 iCub Facility - Istituto Italiano di Tecnologia
+ * Copyright (C) 2019 iCub Facility - Istituto Italiano di Tecnologia
  * Author: Vadim Tikhanoff
  * email:  vadim.tikhanoff@iit.it
  * Permission is granted to copy, distribute, and/or modify this program
@@ -23,8 +23,11 @@
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/sig/Image.h>
+#include <yarp/sig/Vector.h>
 #include <yarp/cv/Cv.h>
 #include <yarp/os/Stamp.h>
+#include <yarp/os/RpcClient.h>
+#include <yarp/math/Math.h>
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/opencv.hpp>
@@ -34,6 +37,8 @@
 #include <iostream>
 #include <utility>
 
+using namespace yarp::math;
+
 /********************************************************/
 class Processing : public yarp::os::BufferedPort<yarp::os::Bottle>
 {
@@ -42,8 +47,28 @@ class Processing : public yarp::os::BufferedPort<yarp::os::Bottle>
     yarp::os::RpcServer handlerPort;
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> >    imageInPort;
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> >    imageOutPort;
+    yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelMono> >   imageOutDepthPort;
+    yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelMono> >   imageOutSegmentPort;
+    yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelFloat>>   imageInFloat;
     yarp::os::BufferedPort<yarp::os::Bottle >    targetPort;
+    yarp::os::BufferedPort<yarp::os::Bottle >    armPort;
     yarp::os::BufferedPort<yarp::os::Bottle >    blobPort;
+    yarp::os::RpcClient camPort;
+
+    int followSkeletonIndex;
+    cv::Mat overlayFrame;
+    cv::Mat overlayObject;
+
+    bool    camera_configured;
+    double  fov_h;
+    double  fov_v;
+
+    double minVal;
+    double maxVal;
+    
+    double isArmLifted;
+
+    yarp::sig::ImageOf<yarp::sig::PixelFloat> depth;
 
 public:
     /********************************************************/
@@ -59,7 +84,19 @@ public:
     };
 
     /********************************************************/
-    bool open(){
+    bool setDepthValues(const double min, const double max ){
+
+        minVal = min;
+        maxVal = max;
+
+        yDebug() << "setting Min val to " << minVal << "setting max val to " << maxVal;
+
+        return true;
+    }
+
+    /********************************************************/
+    bool open()
+    {
 
         this->useCallback();
 
@@ -67,8 +104,24 @@ public:
         imageInPort.open("/" + moduleName + "/image:i");
 
         imageOutPort.open("/" + moduleName + "/image:o");
+        imageOutDepthPort.open("/" + moduleName + "/depth:o");
+        imageOutSegmentPort.open("/" + moduleName + "/segmented:o");
+
         targetPort.open("/" + moduleName + "/target:o");
         blobPort.open("/" + moduleName + "/blobs:o");
+        armPort.open("/" + moduleName + "/speechTrigger:o");
+
+        imageInFloat.open("/" + moduleName + "/float:i");
+
+        camPort.open("/" + moduleName + "/cam:rpc");
+
+        followSkeletonIndex = -1;
+
+        isArmLifted = false;
+        
+        yarp::os::Network::connect("/yarpOpenPose/target:o",this->BufferedPort<yarp::os::Bottle >::getName().c_str());
+        yarp::os::Network::connect("/yarpOpenPose/float:o", imageInFloat.getName().c_str());
+        yarp::os::Network::connect("/yarpOpenPose/image:o", imageInPort.getName().c_str());
 
         return true;
     }
@@ -76,11 +129,16 @@ public:
     /********************************************************/
     void close()
     {
+        imageInFloat.close();
         imageOutPort.close();
         imageInPort.close();
         BufferedPort<yarp::os::Bottle >::close();
         targetPort.close();
         blobPort.close();
+        camPort.close();
+        imageOutDepthPort.close();
+        imageOutSegmentPort.close();
+        armPort.close();
     }
 
     /********************************************************/
@@ -89,17 +147,200 @@ public:
         BufferedPort<yarp::os::Bottle >::interrupt();
     }
 
+    /**********************************************************/
+    int findArmLift( const yarp::os::Bottle &blobs,
+                    const yarp::os::Bottle &skeletons)
+    {
+        int index = -1;
+
+        if (skeletons.size() > 0)
+        {
+            size_t skeletonSize = skeletons.get(0).asList()->size();
+            size_t internalElements = 0;
+
+            yDebug() << "skeleton " << skeletonSize;
+
+            std::vector<cv::Point> relbow;
+            std::vector<cv::Point> rwrist;
+            std::vector<cv::Point> lelbow;
+            std::vector<cv::Point> lwrist;
+            std::vector<cv::Point> neck;
+            std::vector<cv::Point> midHip;
+
+            cv::Point point;
+
+            if (skeletonSize>0)
+                internalElements = skeletons.get(0).asList()->get(0).asList()->size();
+
+            for (size_t i = 0; i < skeletonSize; i++)
+            {
+                if (yarp::os::Bottle *propField = skeletons.get(0).asList()->get(i).asList())
+                {
+                    for (int ii = 0; ii < internalElements; ii++)
+                    {
+                        if (yarp::os::Bottle *propFieldPos = propField->get(ii).asList())
+                        {
+                            if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"RElbow") == 0)
+                            {
+                                point.x = (int)propFieldPos->get(1).asDouble();
+                                point.y = (int)propFieldPos->get(2).asDouble();
+                                relbow.push_back(point);
+                            }
+                            if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"RWrist") == 0)
+                            {
+                                point.x = (int)propFieldPos->get(1).asDouble();
+                                point.y = (int)propFieldPos->get(2).asDouble();
+                                rwrist.push_back(point);
+                            }
+                            if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"LElbow") == 0)
+                            {
+                                point.x = (int)propFieldPos->get(1).asDouble();
+                                point.y = (int)propFieldPos->get(2).asDouble();
+                                lelbow.push_back(point);
+                            }
+                            if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"LWrist") == 0)
+                            {
+                                point.x = (int)propFieldPos->get(1).asDouble();
+                                point.y = (int)propFieldPos->get(2).asDouble();
+                                lwrist.push_back(point);
+                            }
+                            if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"Neck") == 0)
+                            {
+                                point.x = (int)propFieldPos->get(1).asDouble();
+                                point.y = (int)propFieldPos->get(2).asDouble();
+                                neck.push_back(point);
+                            }
+                            if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"MidHip") == 0)
+                            {
+                                point.x = (int)propFieldPos->get(1).asDouble();
+                                point.y = (int)propFieldPos->get(2).asDouble();
+                                midHip.push_back(point);
+                            }
+                        }
+                    }
+                }
+            }
+
+            int getIndex = -1;
+
+            if (neck.size() > 0)
+            {
+                for (int i = 0; i < skeletonSize; i++)
+                {
+                    if ( relbow[i].y - rwrist[i].y > 20 && relbow[i].y > 0 && rwrist[i].y > 0 )
+                    {
+                        getIndex = i;
+                    }
+                    else if( lelbow[i].y - lwrist[i].y > 20 && lelbow[i].y > 0 && lwrist[i].y > 0 )
+                    {
+                        getIndex = i;
+                    }
+                }
+                if (getIndex > -1)
+                {
+                    yError() << "************************" << blobs.size();
+                    for (int i=0;i<blobs.size(); i++)
+                    {
+                        yarp::os::Bottle *item=blobs.get(i).asList();
+
+                        int cog = item->get(0).asInt();//item->get(2).asInt() - ( (item->get(2).asInt() -item->get(0).asInt()) / 2);
+
+                        if ( abs(cog - neck[getIndex].x) < 20)
+                            index = i;
+                    }
+                }
+            }
+        }
+        return index;
+    }
+
+    /********************************************************/
+    bool getCameraOptions()
+    {   fov_h = 55;
+        fov_v = 42;
+        /*if (camPort.getOutputCount()>0)
+        {
+            yarp::os::Bottle cmd,rep;
+            cmd.addVocab(yarp::os::Vocab::encode("visr"));
+            cmd.addVocab(yarp::os::Vocab::encode("get"));
+            cmd.addVocab(yarp::os::Vocab::encode("fov"));
+            if (camPort.write(cmd,rep))
+            {
+                if (rep.size()>=5)
+                {
+                    fov_h=rep.get(3).asDouble();
+                    fov_v=rep.get(4).asDouble();
+                    yInfo()<<"camera fov_h (from sensor) ="<<fov_h;
+                    yInfo()<<"camera fov_v (from sensor) ="<<fov_v;
+                    return true;
+                }
+            }
+        }*/
+
+        return true;
+    }
+
+    /********************************************************/
+    bool getPoint3D(const int u, const int v, yarp::sig::Vector &p) const
+    {
+        if ((u>=0) && (u<depth.width()) && (v>=0) && (v<depth.height()))
+        {
+            double f=depth.width()/(2.0*tan(fov_h*(M_PI/180.0)/2.0));
+            double d=depth(u,v);
+            if ((d>0.0) && (f>0.0))
+            {
+                double x=u-0.5*(depth.width()-1);
+                double y=v-0.5*(depth.height()-1);
+
+                p=d*ones(3);
+                p[0]*=x/f;
+                p[1]*=y/f;
+
+                return true;
+            }
+        }
+        return false;
+    }
+
     /********************************************************/
     void onRead( yarp::os::Bottle &data )
     {
-        yarp::sig::ImageOf<yarp::sig::PixelRgb> &outImage  = imageOutPort.prepare();
+        if (!camera_configured)
+            camera_configured=getCameraOptions();
+
+        yarp::sig::ImageOf<yarp::sig::PixelRgb> &outImage = imageOutPort.prepare();
+        yarp::sig::ImageOf<yarp::sig::PixelMono> &outDepth = imageOutDepthPort.prepare();
+        yarp::sig::ImageOf<yarp::sig::PixelMono> &outSegment = imageOutSegmentPort.prepare();
+        yarp::os::Bottle &triggerSpeech  = armPort.prepare();
+
+        while (imageInPort.getInputCount() < 1 || imageInFloat.getInputCount() < 1 )
+        {
+            yError() << "waiting for connections";
+            yarp::os::Time::delay(0.1);
+        }
+        yDebug()<< "setting up system";
+
+
         yarp::sig::ImageOf<yarp::sig::PixelRgb> *inImage = imageInPort.read();
-        
-        yarp::os::Stamp stamp;        
+        yDebug()<< __LINE__;
+        yarp::sig::ImageOf<yarp::sig::PixelFloat> *float_yarp = imageInFloat.read();
+
+        yDebug()<< __LINE__;
+        depth = *float_yarp;
+        cv::Mat float_cv = yarp::cv::toCvMat(*float_yarp);
+        cv::Mat mono_cv = cv::Mat::ones(float_yarp->height(), float_yarp->width(), CV_8UC1);
+        float_cv -= minVal;
+        float_cv.convertTo(mono_cv, CV_8U, 255.0/(maxVal-minVal) );
+        cv::Mat depth_cv(float_yarp->height(), float_yarp->width(), CV_8UC1, cv::Scalar(255));
+        cv::Mat segment_cv(inImage->height(), inImage->width(), CV_8UC1, cv::Scalar(0));
+        depth_cv = depth_cv - mono_cv;
+        cv::Mat mask;
+        inRange(depth_cv, cv::Scalar(255), cv::Scalar(255), mask);
+        cv::Mat black_image(depth_cv.size(), CV_8U, cv::Scalar(0));
+        black_image.copyTo(depth_cv, mask);
+        yarp::os::Stamp stamp;
         imageInPort.getEnvelope(stamp);
-
         yarp::os::Bottle &target  = targetPort.prepare();
-
         size_t skeletonSize = data.get(0).asList()->size();
         size_t internalElements = 0;
 
@@ -113,6 +354,8 @@ public:
 
         outImage.resize(inImage->width(), inImage->height());
 
+        std::vector<cv::Point> rightEye2D;
+        std::vector<cv::Point> leftEye2D;
         std::vector<cv::Point> neck2D;
         std::vector<cv::Point> nose2D;
         std::vector<cv::Point> rightEar2D;
@@ -121,10 +364,19 @@ public:
         std::vector<cv::Point> rightShoulder2D;
         std::vector<cv::Point> rightWrist2D;
         std::vector<cv::Point> leftWrist2D;
+        std::vector<cv::Point> rightElbow2D;
+        std::vector<cv::Point> leftElbow2D;
+        std::vector<cv::Point> MidHip2D;
+        std::vector<cv::Point> LHip2D;
+        std::vector<cv::Point> RHip2D;
         cv::Point point;
 
         std::vector<yarp::os::Bottle> shapes;
+        shapes.clear();
         std::vector<std::pair <int,int> > elements;
+        elements.clear();
+
+        yDebug() << "skeletonSize" << skeletonSize;
 
         for (int i = 0; i < skeletonSize; i++)
         {
@@ -134,6 +386,18 @@ public:
                 {
                     if (yarp::os::Bottle *propFieldPos = propField->get(ii).asList())
                     {
+                        if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"REye") == 0)
+                        {
+                            point.x = (int)propFieldPos->get(1).asDouble();
+                            point.y = (int)propFieldPos->get(2).asDouble();
+                            rightEye2D.push_back(point);
+                        }
+                        if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"LEye") == 0)
+                        {
+                            point.x = (int)propFieldPos->get(1).asDouble();
+                            point.y = (int)propFieldPos->get(2).asDouble();
+                            leftEye2D.push_back(point);
+                        }
                         if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"REar") == 0)
                         {
                             point.x = (int)propFieldPos->get(1).asDouble();
@@ -151,6 +415,7 @@ public:
                             point.x = (int)propFieldPos->get(1).asDouble();
                             point.y = (int)propFieldPos->get(2).asDouble();
                             neck2D.push_back(point);
+
                         }
                         if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"Nose") == 0)
                         {
@@ -170,7 +435,6 @@ public:
                             point.y = (int)propFieldPos->get(2).asDouble();
                             rightShoulder2D.push_back(point);
                         }
-
                         if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"RWrist") == 0)
                         {
                             point.x = (int)propFieldPos->get(1).asDouble();
@@ -182,6 +446,37 @@ public:
                             point.x = (int)propFieldPos->get(1).asDouble();
                             point.y = (int)propFieldPos->get(2).asDouble();
                             leftWrist2D.push_back(point);
+                        }
+
+                        if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"RElbow") == 0)
+                        {
+                            point.x = (int)propFieldPos->get(1).asDouble();
+                            point.y = (int)propFieldPos->get(2).asDouble();
+                            rightElbow2D.push_back(point);
+                        }
+                        if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"LElbow") == 0)
+                        {
+                            point.x = (int)propFieldPos->get(1).asDouble();
+                            point.y = (int)propFieldPos->get(2).asDouble();
+                            leftElbow2D.push_back(point);
+                        }
+                        if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"MidHip") == 0)
+                        {
+                            point.x = (int)propFieldPos->get(1).asDouble();
+                            point.y = (int)propFieldPos->get(2).asDouble();
+                            MidHip2D.push_back(point);
+                        }
+                        if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"LHip") == 0)
+                        {
+                            point.x = (int)propFieldPos->get(1).asDouble();
+                            point.y = (int)propFieldPos->get(2).asDouble();
+                            LHip2D.push_back(point);
+                        }
+                        if ( std::strcmp (propFieldPos->get(0).asString().c_str(),"RHip") == 0)
+                        {
+                            point.x = (int)propFieldPos->get(1).asDouble();
+                            point.y = (int)propFieldPos->get(2).asDouble();
+                            RHip2D.push_back(point);
                         }
                     }
                 }
@@ -199,144 +494,37 @@ public:
             cv::Point topLeft;
             cv::Point bottomRight;
 
-            int length = 0;
-            int shift = 10;
-
-            if (nose2D[i].x > 0)
+            yInfo() << "###########";
+            yInfo() << "MidHip2D " << MidHip2D[i].x << MidHip2D[i].y << "NecK2D " << neck2D[i].x << neck2D[i].y;
+            yarp::os::Bottle tmp;
+            tmp.clear();
+            if (MidHip2D[i].x > 0)
             {
-                if (leftEar2D[i].x > 0 && rightEar2D[i].x > 0)
-                {
-                    length = leftEar2D[i].x - rightEar2D[i].x;
-                    topLeft.x = rightEar2D[i].x - shift;
-                    topLeft.y = rightEar2D[i].y - length;
+                yInfo() << "in midHip";
+                tmp.addInt(MidHip2D[i].x);
+                tmp.addInt(MidHip2D[i].y);
 
-                    bottomRight.x = leftEar2D[i].x + shift;
-                    bottomRight.y = leftEar2D[i].y + length;
-                }
-                else if (leftEar2D[i].x == 0 && rightEar2D[i].x > 0)
-                {
-                    length = nose2D[i].x - rightEar2D[i].x;
-                    topLeft.x = rightEar2D[i].x - shift;
-                    topLeft.y = rightEar2D[i].y - length;
-
-                    bottomRight.x = nose2D[i].x + shift;
-                    bottomRight.y = nose2D[i].y + length;
-                }
-                else if (rightEar2D[i].x == 0 && leftEar2D[i].x > 0)
-                {
-                    length = leftEar2D[i].x - nose2D[i].x;
-                    topLeft.x = nose2D[i].x - shift;
-                    topLeft.y = nose2D[i].y - length;
-
-                    bottomRight.x = leftEar2D[i].x + shift;
-                    bottomRight.y = leftEar2D[i].y + length;
-                }
-
-                if (topLeft.x < 1)
-                    topLeft.x = 1;
-                else if (topLeft.x > 319)
-                    topLeft.x = 319;
-                else if (topLeft.y < 1)
-                    topLeft.y = 1;
-                else if (topLeft.y > 239)
-                    topLeft.y = 239;
-
-                if (bottomRight.x < 1)
-                    bottomRight.x = 1;
-                else if (bottomRight.x > 319)
-                    bottomRight.x = 319;
-                else if (bottomRight.y < 1)
-                    bottomRight.y = 1;
-                else if (bottomRight.y > 239)
-                    bottomRight.y = 239;
-
-                circle(out_cv, topLeft, 3, cv::Scalar(0, 255 , 0), 1, 8);
-                circle(out_cv, bottomRight, 3, cv::Scalar(0, 255 , 0), 1, 8);
-
-                cv::rectangle(out_cv, topLeft, bottomRight, cv::Scalar(0, 255, 0), 2, 8);
-
-                yarp::os::Bottle tmp;
-                yInfo() << "###########";
-                yInfo() << topLeft.x << topLeft.y << bottomRight.x << bottomRight.y;
-
-                if (topLeft.x < bottomRight.x && topLeft.y < bottomRight.y)
-                {
-                    tmp.addInt(topLeft.x);
-                    tmp.addInt(topLeft.y);
-                    tmp.addInt(bottomRight.x);
-                    tmp.addInt(bottomRight.y);
-                    yInfo() << "IN NORMAL" << tmp.toString();
-                    elements.push_back(std::make_pair(topLeft.x,increment));
-                    shapes.push_back(tmp);
-                    increment++;
-                }
-                else
-                {
-                    tmp.addInt(topLeft.x);
-                    tmp.addInt(topLeft.y);
-                    tmp.addInt(bottomRight.x);
-                    tmp.addInt(bottomRight.y);
-                    yError() << "WTF NORMAL" << tmp.toString();
-                }
+                elements.push_back(std::make_pair(MidHip2D[i].x,increment));
+                shapes.push_back(tmp);
+                increment++;
+            }
+            else if (neck2D[i].x > 0)
+            {
+                yInfo() << "in neck";
+                tmp.addInt(neck2D[i].x);
+                tmp.addInt(neck2D[i].y);
+                elements.push_back(std::make_pair(neck2D[i].x,increment));
+                shapes.push_back(tmp);
+                increment++;
             }
             else
             {
-                if (leftEar2D[i].x > 0 && rightEar2D[i].x > 0)
-                {
-                    length = rightEar2D[i].x - leftEar2D[i].x;
-                    topLeft.x = leftEar2D[i].x - shift;
-                    topLeft.y = leftEar2D[i].y - length;
-
-                    bottomRight.x = rightEar2D[i].x + shift;
-                    bottomRight.y = rightEar2D[i].y + length;
-
-                    if (topLeft.x < 1)
-                        topLeft.x = 1;
-                    else if (topLeft.x > 319)
-                        topLeft.x = 319;
-                    else if (topLeft.y < 1)
-                        topLeft.y = 1;
-                    else if (topLeft.y > 239)
-                        topLeft.y = 239;
-
-                    if (bottomRight.x < 1)
-                        bottomRight.x = 1;
-                    else if (bottomRight.x > 319)
-                        bottomRight.x = 319;
-                    else if (bottomRight.y < 1)
-                        bottomRight.y = 1;
-                    else if (bottomRight.y > 239)
-                        bottomRight.y = 239;
-
-                    circle(out_cv, topLeft, 3, cv::Scalar(255, 0 , 0), 1, 8);
-
-                    cv::rectangle(out_cv, topLeft, bottomRight, cv::Scalar( 255, 0, 0), 2, 8);
-
-                    yarp::os::Bottle tmp;
-
-                    if (topLeft.x < bottomRight.x && topLeft.y < bottomRight.y)
-                    {
-                        tmp.addInt(topLeft.x);
-                        tmp.addInt(topLeft.y);
-                        tmp.addInt(bottomRight.x);
-                        tmp.addInt(bottomRight.y);
-                        yInfo() << "IN REVERSED" << tmp.toString();
-                        elements.push_back(std::make_pair(topLeft.x, increment));
-                        shapes.push_back(tmp);
-                        increment++;
-                    }
-                    else
-                    {
-                        tmp.addInt(topLeft.x);
-                        tmp.addInt(topLeft.y);
-                        tmp.addInt(bottomRight.x);
-                        tmp.addInt(bottomRight.y);
-                        yError() << "WTF REVERSED" << tmp.toString();
-                    }
-                }
+                yError() << "Cannot compute...cannot detect anything";
             }
         }
 
+        yarp::os::Bottle list;
+        yInfo() << "**************** Skeleton Size" << skeletonSize << "Element SIZE " << elements.size() << "shape SIZE"  << shapes.size() ;
         if (elements.size()>0)
         {
             for (int i=0; i<elements.size(); i++)
@@ -349,27 +537,262 @@ public:
 
             if ( shapes.size() > 0)
             {
-                yarp::os::Bottle &blobs  = blobPort.prepare();
+                yarp::os::Bottle blobs;
                 blobs.clear();
 
-                yInfo() << "**************** SIZE" << elements.size() << shapes.size() ;
                 for (int i=0; i<shapes.size(); i++)
                 {
-                    yInfo() << "**************** " << shapes[elements[i].second].toString();
+                    yInfo() << "**************** shapes elements" << shapes[elements[i].second].toString();
                     yarp::os::Bottle &tmp = blobs.addList();
                     tmp.addInt(shapes[elements[i].second].get(0).asInt());
                     tmp.addInt(shapes[elements[i].second].get(1).asInt());
-                    tmp.addInt(shapes[elements[i].second].get(2).asInt());
-                    tmp.addInt(shapes[elements[i].second].get(3).asInt());
                 }
+
+                list = blobs;
                 targetPort.setEnvelope(stamp);
                 targetPort.write();
             }
         }
+
+        if ( shapes.size() > 0)
+        {
+            int index = findArmLift(list, data);
+            out_cv.copyTo(overlayFrame);
+            out_cv.copyTo(overlayObject);
+
+            if (index > -1 )
+                followSkeletonIndex = index;
+
+            yDebug() << " Looking at skeleton " << followSkeletonIndex;
+
+            int finalIndex = -1;
+            for (int i=0;i<list.size(); i++)
+            {
+                yarp::os::Bottle *item=list.get(i).asList();
+
+                int cog = item->get(0).asInt(); //item->get(2).asInt() - ( (item->get(2).asInt() -item->get(0).asInt()) / 2);
+
+                if ( abs(cog - neck2D[followSkeletonIndex].x) < 30)
+                    finalIndex = i;
+            }
+
+            if (followSkeletonIndex > -1 && finalIndex > -1)
+            {
+                yDebug() << "Final index is " << finalIndex;
+
+                if (leftEye2D[finalIndex].x > 0 && leftEye2D[finalIndex].y > 0 && leftEye2D[finalIndex].x > 0 && leftEye2D[finalIndex].y > 0)
+                    line(overlayFrame, leftEye2D[finalIndex], nose2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (rightEye2D[finalIndex].x > 0 && rightEye2D[finalIndex].y > 0 && nose2D[finalIndex].x > 0 && nose2D[finalIndex].y > 0)
+                    line(overlayFrame, rightEye2D[finalIndex], nose2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (leftEar2D[finalIndex].x > 0 && leftEar2D[finalIndex].y > 0 && leftEye2D[finalIndex].x > 0 && leftEye2D[finalIndex].y > 0)
+                    line(overlayFrame, leftEye2D[finalIndex], leftEar2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (rightEar2D[finalIndex].x > 0 && rightEar2D[finalIndex].y > 0 && rightEye2D[finalIndex].x > 0 && rightEye2D[finalIndex].y > 0)
+                    line(overlayFrame, rightEye2D[finalIndex], rightEar2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (nose2D[finalIndex].x > 0 && nose2D[finalIndex].y > 0 && neck2D[finalIndex].x > 0 && neck2D[finalIndex].y > 0)
+                    line(overlayFrame, nose2D[finalIndex], neck2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (neck2D[finalIndex].x > 0 && neck2D[finalIndex].y > 0 && leftShoulder2D[finalIndex].x > 0 && leftShoulder2D[finalIndex].y > 0)
+                    line(overlayFrame, neck2D[finalIndex], leftShoulder2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (leftElbow2D[finalIndex].x > 0 && leftElbow2D[finalIndex].y > 0 && leftShoulder2D[finalIndex].x > 0 && leftShoulder2D[finalIndex].y > 0)
+                    line(overlayFrame, leftShoulder2D[finalIndex], leftElbow2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (leftWrist2D[finalIndex].x > 0 && leftWrist2D[finalIndex].y > 0 && leftElbow2D[finalIndex].x > 0 && leftElbow2D[finalIndex].y > 0)
+                    line(overlayFrame, leftElbow2D[finalIndex], leftWrist2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (neck2D[finalIndex].x > 0 && neck2D[finalIndex].y > 0 && rightShoulder2D[finalIndex].x > 0 && rightShoulder2D[finalIndex].y > 0)
+                    line(overlayFrame, neck2D[finalIndex], rightShoulder2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (rightElbow2D[finalIndex].x > 0 && rightElbow2D[finalIndex].y > 0 && rightShoulder2D[finalIndex].x > 0 && rightShoulder2D[finalIndex].y > 0)
+                    line(overlayFrame, rightShoulder2D[finalIndex], rightElbow2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (rightWrist2D[finalIndex].x > 0 && rightWrist2D[finalIndex].y > 0 && rightElbow2D[finalIndex].x > 0 && rightElbow2D[finalIndex].y > 0)
+                    line(overlayFrame, rightElbow2D[finalIndex], rightWrist2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+
+                if (RHip2D[finalIndex].x > 0 && LHip2D[finalIndex].x > 0 && neck2D[finalIndex].x > 0 && neck2D[finalIndex].y > 0)
+                {
+                    line(overlayFrame, neck2D[finalIndex], LHip2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+                    line(overlayFrame, neck2D[finalIndex], RHip2D[finalIndex], cv::Scalar(118, 185 , 0), 4, 8);
+                }
+
+                double opacity = 0.4;
+                cv::addWeighted(overlayFrame, opacity, out_cv, 1 - opacity, 0, out_cv);
+
+                yDebug() << "neck 2D " << neck2D[finalIndex].x << neck2D[finalIndex].y;
+                yDebug() << "left wrist 2D " << leftWrist2D[finalIndex].x << leftWrist2D[finalIndex].y;
+                yDebug() << "right wrist 2D " << rightWrist2D[finalIndex].x << rightWrist2D[finalIndex].y;
+                yDebug() << "left elbow 2D " << leftElbow2D[finalIndex].x << leftElbow2D[finalIndex].y;
+                yDebug() << "right elbow 2D " << rightElbow2D[finalIndex].x << rightElbow2D[finalIndex].y;
+                yDebug() << "right hip 2D " << RHip2D[finalIndex].x << RHip2D[finalIndex].y;
+                yDebug() << "left hip 2D " << LHip2D[finalIndex].x << LHip2D[finalIndex].y;
+                //yDebug() << "mid hip 2D " << MidHip2D[finalIndex].x << MidHip2D[finalIndex].y;
+
+                std::map< double, cv::Point> valueVector;
+
+                double noseValue = depth_cv.at<uchar>(nose2D[finalIndex]);
+                double neckValue = depth_cv.at<uchar>(neck2D[finalIndex]);
+                double leftWristValue = depth_cv.at<uchar>(leftWrist2D[finalIndex]);
+                double rightWristValue = depth_cv.at<uchar>(rightWrist2D[finalIndex]);
+                double leftElbowValue = depth_cv.at<uchar>(leftElbow2D[finalIndex]);
+                double rightElbowValue = depth_cv.at<uchar>(rightElbow2D[finalIndex]);
+                //double midHipValue = depth_cv.at<uchar>(MidHip2D[finalIndex]);
+                double rightHipValue = depth_cv.at<uchar>(RHip2D[finalIndex]);
+                double leftHipValue = depth_cv.at<uchar>(LHip2D[finalIndex]);
+
+                valueVector.insert(std::make_pair(neckValue, neck2D[finalIndex]));
+                valueVector.insert(std::make_pair(leftWristValue, leftWrist2D[finalIndex]));
+                valueVector.insert(std::make_pair(rightWristValue, rightWrist2D[finalIndex]));
+                valueVector.insert(std::make_pair(leftElbowValue, leftElbow2D[finalIndex]));
+                valueVector.insert(std::make_pair(rightElbowValue, rightElbow2D[finalIndex]));
+                //valueVector.insert(std::make_pair(midHipValue, MidHip2D[finalIndex]));
+                valueVector.insert(std::make_pair(rightHipValue, RHip2D[finalIndex]));
+                valueVector.insert(std::make_pair(leftHipValue, LHip2D[finalIndex]));
+
+                double minLocVal, maxLocVal;
+                cv::Point minLoc, maxLoc;
+                cv::minMaxLoc( depth_cv, &minLocVal, &maxLocVal, &minLoc, &maxLoc );
+
+                //yDebug() << midHipValue << rightHipValue << leftHipValue << neckValue << leftWristValue << rightWristValue << leftElbowValue << rightElbowValue;
+                yDebug() << "Values " << neckValue << noseValue << leftWristValue << rightWristValue << leftElbowValue << rightElbowValue << rightHipValue << leftHipValue;
+
+                std::map<double, cv::Point>::iterator it = valueVector.begin();
+
+                double max = 0.0;
+                cv::Point maxPoint;
+                while(it != valueVector.end())
+                {
+                    if (it->first>max)
+                    {
+                        max = it->first;
+                        maxPoint = it->second;
+                    }
+                    it++;
+                }
+
+                yDebug() << "Max value: " << max << " max Point " << maxPoint.x << maxPoint.y;
+
+                double maxValThreshed = (max - 3);
+
+                cv::Mat cleanedImg;
+                cv::threshold(depth_cv, cleanedImg, maxValThreshed, 255, cv::THRESH_BINARY);
+
+                cv::Mat kernel1 = cv::Mat::ones(3, 3, CV_8UC1);
+                dilate(cleanedImg, cleanedImg, kernel1);
+
+                std::vector<std::vector<cv::Point> > cnt;
+
+                findContours(cleanedImg, cnt, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_NONE);
+
+                std::vector<cv::Moments> mu( cnt.size() );
+                std::vector<cv::Point2f> mc( cnt.size() );
+
+                std::vector<std::vector<cv::Point> > contours_poly( cnt.size() );
+                std::vector<cv::Rect> boundRect( cnt.size() );
+
+                yarp::os::Bottle &blobs  = blobPort.prepare();
+                blobs.clear();
+
+                double minValue = 1000;
+                int minValueIndex = -1;
+
+                for( size_t i = 0; i< cnt.size(); i++ )
+                {
+                    mu[i] = moments( cnt[i], false );
+                    mc[i] = cv::Point2f( mu[i].m10/mu[i].m00 , mu[i].m01/mu[i].m00 );
+                    double res = cv::norm(cv::Point(mc[i].x, mc[i].y) - maxPoint);
+
+                    yDebug() << "res" << res;
+                    if (res<minValue)
+                    {
+                        minValue = res;
+                        minValueIndex = i;
+                    }
+                }
+                yDebug() << "res minValue " << minValue << "index" << minValueIndex;
+
+                double checkValueOne = 0.0;
+                double checkValueTwo = 0.0;
+
+                if (neckValue > 0 && noseValue > 0)
+                {
+                    yError() << "USING NECK";
+                    checkValueOne = fabs(max-neckValue);
+                    checkValueTwo = fabs(max-noseValue);
+                }
+                else
+                {
+                    yError() << "USING HIP ";
+                    checkValueOne = fabs(max-rightHipValue);
+                    checkValueTwo = fabs(max-leftHipValue);
+                }
+
+                yError() << mc[minValueIndex].x << mc[minValueIndex].y;
+                yError() << maxPoint.x << maxPoint.y;
+                yError() << "Distance from " << minValueIndex << " is " << minValue;
+                yError() << "checkValueOne vs max " << checkValueOne;
+                yError() << "checkvalueTwo vs max " << checkValueTwo;
+
+                if ( checkValueOne >= 15 || checkValueTwo >= 15 )
+                {
+                    approxPolyDP( cv::Mat(cnt[minValueIndex]), contours_poly[minValueIndex], 3, true );
+                    boundRect[minValueIndex] = boundingRect( cv::Mat(contours_poly[minValueIndex]) );
+
+                    drawContours(depth_cv, cnt, minValueIndex, cv::Scalar(255), 8);
+                    drawContours(overlayObject, cnt, minValueIndex, cv::Scalar(216, 102 , 44), -1);
+                    drawContours(segment_cv, cnt, minValueIndex, cv::Scalar(255), -1);
+                    rectangle( out_cv, boundRect[minValueIndex].tl(), boundRect[minValueIndex].br(), cv::Scalar(216, 102 , 44), 2, 8, 0 );
+
+                    yarp::os::Bottle &tmp = blobs.addList();
+                    tmp.addInt( boundRect[minValueIndex].tl().x );
+                    tmp.addInt( boundRect[minValueIndex].tl().y );
+                    tmp.addInt( boundRect[minValueIndex].br().x );
+                    tmp.addInt( boundRect[minValueIndex].br().y );
+
+                    blobPort.setEnvelope(stamp);
+                    blobPort.write();
+
+                    double opacity = 0.4;
+                    cv::addWeighted(overlayObject, opacity, out_cv, 1 - opacity, 0, out_cv);
+                }
+                //send arm trigger
+                triggerSpeech.clear();
+                if (index > -1 && isArmLifted==false)
+                {
+                    isArmLifted = true;
+                    triggerSpeech.addString("start");
+                    armPort.write();
+                }
+                else if (isArmLifted==true && index < 0)
+                {
+                    isArmLifted = false;
+                    triggerSpeech.addString("stop");
+                    armPort.write();
+                }
+                else
+                    triggerSpeech.clear();
+            }
+            else
+                followSkeletonIndex = -1;
+        }
+
+        yDebug() << "sending images";
+
+        outImage = yarp::cv::fromCvMat<yarp::sig::PixelRgb>(out_cv);
+        outDepth = yarp::cv::fromCvMat<yarp::sig::PixelMono>(depth_cv);
+        outSegment = yarp::cv::fromCvMat<yarp::sig::PixelMono>(segment_cv);
+
         imageOutPort.setEnvelope(stamp);
         imageOutPort.write();
-        blobPort.setEnvelope(stamp);
-        blobPort.write();
+        imageOutDepthPort.setEnvelope(stamp);
+        imageOutDepthPort.write();
+        imageOutSegmentPort.setEnvelope(stamp);
+        imageOutSegmentPort.write();
+
+        yDebug() << "done loop";
     }
 };
 
@@ -384,6 +807,9 @@ class Module : public yarp::os::RFModule
 
     bool                        closing;
 
+    double minVal;
+    double maxVal;
+
 public:
 
     /********************************************************/
@@ -391,6 +817,8 @@ public:
     {
         this->rf=&rf;
         std::string moduleName = rf.check("name", yarp::os::Value("humanStructure"), "module name (string)").asString();
+        minVal = rf.check("minVal", yarp::os::Value(0.5), "minimum value for depth (double)").asDouble();
+        maxVal = rf.check("maxVal", yarp::os::Value(3.5), "maximum value for depth (double)").asDouble();
         setName(moduleName.c_str());
 
         rpcPort.open(("/"+getName("/rpc")).c_str());
@@ -400,6 +828,8 @@ public:
         processing = new Processing( moduleName );
         /* now start the thread to do the work */
         processing->open();
+
+        processing->setDepthValues(minVal, maxVal);
 
         attach(rpcPort);
 

--- a/modules/humanStructure/main.cpp
+++ b/modules/humanStructure/main.cpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <iostream>
 #include <utility>
+#include <cmath>
 
 using namespace yarp::math;
 
@@ -66,7 +67,7 @@ class Processing : public yarp::os::BufferedPort<yarp::os::Bottle>
     double minVal;
     double maxVal;
     
-    double isArmLifted;
+    bool isArmLifted;
 
     yarp::sig::ImageOf<yarp::sig::PixelFloat> depth;
 

--- a/modules/humanStructure/main.cpp
+++ b/modules/humanStructure/main.cpp
@@ -109,7 +109,7 @@ public:
 
         targetPort.open("/" + moduleName + "/target:o");
         blobPort.open("/" + moduleName + "/blobs:o");
-        armPort.open("/" + moduleName + "/speechTrigger:o");
+        armPort.open("/" + moduleName + "/trigger:o");
 
         imageInFloat.open("/" + moduleName + "/float:i");
 

--- a/modules/humanStructure/main.cpp
+++ b/modules/humanStructure/main.cpp
@@ -52,9 +52,9 @@ class Processing : public yarp::os::BufferedPort<yarp::os::Bottle>
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelMono> >   imageOutSegmentPort;
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelFloat>>   imageInFloat;
     yarp::os::BufferedPort<yarp::os::Bottle >    targetPort;
-    yarp::os::BufferedPort<yarp::os::Bottle >    armPort;
     yarp::os::BufferedPort<yarp::os::Bottle >    blobPort;
     yarp::os::RpcClient camPort;
+    yarp::os::RpcClient armPort;
 
     int followSkeletonIndex;
     cv::Mat overlayFrame;
@@ -763,15 +763,17 @@ public:
                 triggerSpeech.clear();
                 if (index > -1 && isArmLifted==false)
                 {
+                    yarp::os::Bottle cmd,rep;
+                    cmd.addVocab(yarp::os::Vocab::encode("start"));
                     isArmLifted = true;
-                    triggerSpeech.addString("start");
-                    armPort.write();
+                    armPort.write(cmd,rep);
                 }
                 else if (isArmLifted==true && index < 0)
                 {
+                    yarp::os::Bottle cmd,rep;
+                    cmd.addVocab(yarp::os::Vocab::encode("stop"));
                     isArmLifted = false;
-                    triggerSpeech.addString("stop");
-                    armPort.write();
+                    armPort.write(cmd,rep);
                 }
                 else
                     triggerSpeech.clear();


### PR DESCRIPTION
This PR changes the ```humanStructure``` to include various enhancements of which :

1. Verify and **order** skeletons (left to right)
1. Select which skeleton to **track** (by lifting the arm)
1. Segment **Region of Interest** of the selected skeleton
1. Send a **trigger** to the speech pipeline in order to **start** and **stop** the **speech acquisition**. This is activated by **lifting the arm**, which sends a start trigger, keeping it up until the speech request is done, and **putting it back down** again to send the stop trigger