### PR TITLE
Fix attention raise hand

### DIFF
--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -53,7 +53,7 @@
 
     <module>
        <name>attentionManager</name>
-       <parameters></parameters>
+       <parameters>--frame world</parameters>
        <node>r1-console-linux</node>
     </module>
 

--- a/modules/attentionManager/attentionManager.xml
+++ b/modules/attentionManager/attentionManager.xml
@@ -22,6 +22,7 @@
     <param default="false" desc="Enable virtual modality.">virtual-mode</param>
     <param default="robot" desc="Tag of the robot's skeleton.">robot-skeleton-name</param>
     <param default="30" desc="Order of the median filter applied to the estimates of the end-line.">line-filter-order</param>
+    <param default="camera" desc="Frame wrt which the skeleton is transformed (camera or world).">frame</param>
   </arguments>
 
   <authors>

--- a/modules/attentionManager/src/main.cpp
+++ b/modules/attentionManager/src/main.cpp
@@ -58,6 +58,7 @@ class Attention : public RFModule, public attentionManager_IDL
     string tag;
     string keypoint;
     string robot_skeleton_name;
+    string frame;
 
     mutex mtx;
     BufferedPort<Bottle> opcPort;
@@ -220,18 +221,25 @@ class Attention : public RFModule, public attentionManager_IDL
     /****************************************************************/
     bool is_with_raised_hand(const shared_ptr<Skeleton> &s) const
     {
+        int dir=1;
+        double k=1.0;
+        if (frame=="world")
+        {
+            dir=2;
+            k=-1.0;
+        }
         if ((*s)[KeyPointTag::elbow_left]->isUpdated() &&
             (*s)[KeyPointTag::hand_left]->isUpdated())
         {
-            if (((*s)[KeyPointTag::elbow_left]->getPoint()[1]>
-                 (*s)[KeyPointTag::hand_left]->getPoint()[1]))
+            if (k*(((*s)[KeyPointTag::elbow_left]->getPoint()[dir]-
+                    (*s)[KeyPointTag::hand_left]->getPoint()[dir]))>0)
                 return true;
         }
         if ((*s)[KeyPointTag::elbow_right]->isUpdated() &&
             (*s)[KeyPointTag::hand_right]->isUpdated())
         {
-            if (((*s)[KeyPointTag::elbow_right]->getPoint()[1]>
-                 (*s)[KeyPointTag::hand_right]->getPoint()[1]))
+            if (k*(((*s)[KeyPointTag::elbow_right]->getPoint()[dir]-
+                    (*s)[KeyPointTag::hand_right]->getPoint()[dir]))>0)
                 return true;
         }
         return false;
@@ -426,6 +434,7 @@ class Attention : public RFModule, public attentionManager_IDL
         inactivity_thres=rf.check("inactivity-thres",Value(0.05)).asDouble();
         virtual_mode=rf.check("virtual-mode",Value(false)).asBool();
         robot_skeleton_name=rf.check("robot-skeleton-name",Value("robot")).asString();
+        frame=rf.check("frame",Value("camera")).asString();
 
         opcPort.open("/attentionManager/opc:i");
         gazeCmdPort.open("/attentionManager/gaze/cmd:rpc");

--- a/modules/managerTUG/app/conf/speak-en.ini
+++ b/modules/managerTUG/app/conf/speak-en.ini
@@ -1,5 +1,5 @@
 [general]
-num-sections    27
+num-sections    29
 
 [section-0]
 key             "ouch"
@@ -112,3 +112,7 @@ value           "Finally, you will have to go back and seat down again."
 [section-27]
 key             "line-crossed"
 value           "Well done! You crossed the line on the floor."
+
+[section-28]
+key             "reinforce-engage"
+value           "Come on! Raise your hand and let's start the exercise."

--- a/modules/managerTUG/app/conf/speak-it.ini
+++ b/modules/managerTUG/app/conf/speak-it.ini
@@ -1,5 +1,5 @@
 [general]
-num-sections    28
+num-sections    29
 
 [section-0]
 key             "ouch"
@@ -112,3 +112,7 @@ value           "Infine dovrai tornare indietro e risederti."
 [section-27]
 key             "line-crossed"
 value           "Ben fatto! Hai superato la linea sul pavimento."
+
+[section-28]
+key             "reinforce-engage"
+value           "Coraggio! Alza la mano e cominciamo l'esercizio."

--- a/modules/managerTUG/src/main.cpp
+++ b/modules/managerTUG/src/main.cpp
@@ -258,7 +258,7 @@ class Manager : public RFModule, public managerTUG_IDL
     State prev_state;
     string tag;
     double t0,tstart,t;
-    int encourage_cnt;
+    int encourage_cnt,reinforce_engage_cnt;
     unordered_map<string,string> speak_map;
     unordered_map<string,int> speak_count_map;
     bool interrupting;
@@ -823,6 +823,8 @@ class Manager : public RFModule, public managerTUG_IDL
                     speak("engage",true);
                     state=State::follow;
                     encourage_cnt=0;
+                    reinforce_engage_cnt=0;
+                    t0=Time::now();
                 }
             }
         }
@@ -838,6 +840,19 @@ class Manager : public RFModule, public managerTUG_IDL
                 {
                     speak("accepted",true);
                     state=State::engaged;
+                }
+                else if (Time::now()-t0>10.0)
+                {
+                    if (++reinforce_engage_cnt<=1)
+                    {
+                        speak("reinforce-engage",true);
+                        t0=Time::now();
+                    }
+                    else
+                    {
+                        speak("disengaged",true);
+                        disengage();
+                    }
                 }
             }
         }


### PR DESCRIPTION
`attentionManager` assumes the skeleton to be in the camera frame when estimating if the hand is raised. I added the parameter `frame`, which can be `camera-frame` (skeleton wrt to the camera) or `line-frame` (skeleton wrt to start line) and generalized the hand raised up detection.