### PR TITLE
Using 3D skeleton to detect hand up

### DIFF
--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -372,6 +372,12 @@
     </connection>
 
     <connection>
+        <from>/managerTUG/trigger:o</from>
+        <to>/googleSpeech/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
         <from>/managerTUG/left_arm:rpc</from>
         <to>/ctpservice/left_arm/rpc</to>
         <protocol>fast_tcp</protocol>

--- a/modules/humanStructure/main.cpp
+++ b/modules/humanStructure/main.cpp
@@ -763,17 +763,23 @@ public:
                 //send arm trigger
                 if (index > -1 && isArmLifted==false)
                 {
-                    yarp::os::Bottle cmd,rep;
-                    cmd.addString("start");
-                    isArmLifted = true;
-                    armPort.write(cmd,rep);
+                    if (armPort.getOutputCount() > 0)
+                    {
+                        yarp::os::Bottle cmd,rep;
+                        cmd.addString("start");
+                        isArmLifted = true;
+                        armPort.write(cmd,rep);
+                    }
                 }
                 else if (isArmLifted==true && index < 0)
                 {
-                    yarp::os::Bottle cmd,rep;
-                    cmd.addString("stop");
-                    isArmLifted = false;
-                    armPort.write(cmd,rep);
+                    if (armPort.getOutputCount() > 0)
+                    {
+                        yarp::os::Bottle cmd,rep;
+                        cmd.addString("stop");
+                        isArmLifted = false;
+                        armPort.write(cmd,rep);
+                    }
                 }
             }
             else

--- a/modules/managerTUG/app/conf/config-en.ini
+++ b/modules/managerTUG/app/conf/config-en.ini
@@ -8,3 +8,5 @@ pointing-time             3.0
 pointing-home             (-10.0 20.0 -10.0 35.0 0.0 0.030 0.0 0.0) 
 pointing-start            (70.0 12.0 -10.0 10.0 0.0 0.050 0.0 0.0)  
 pointing-finish           (35.0 12.0 -10.0 10.0 0.0 0.050 0.0 0.0)
+detect-hand-up            true
+arm-thresh                0.6

--- a/modules/managerTUG/app/conf/config-it.ini
+++ b/modules/managerTUG/app/conf/config-it.ini
@@ -8,3 +8,5 @@ pointing-time             3.0
 pointing-home             (-10.0 20.0 -10.0 35.0 0.0 0.030 0.0 0.0) 
 pointing-start            (70.0 12.0 -10.0 10.0 0.0 0.050 0.0 0.0)  
 pointing-finish           (35.0 12.0 -10.0 10.0 0.0 0.050 0.0 0.0)
+detect-hand-up            true
+arm-thresh                0.6

--- a/modules/managerTUG/app/conf/speak-en.ini
+++ b/modules/managerTUG/app/conf/speak-en.ini
@@ -1,5 +1,5 @@
 [general]
-num-sections    29
+num-sections    30
 
 [section-0]
 key             "ouch"
@@ -91,7 +91,7 @@ value           "I'm sorry. I don't know how to answer to this question."
 
 [section-22]
 key             "questions"
-value           "Everything clear?"
+value           "If you want to ask me a question, please keep your hand up."
 
 [section-23]
 key             "line"
@@ -114,5 +114,9 @@ key             "line-crossed"
 value           "Well done! You crossed the line on the floor."
 
 [section-28]
+key             "asking"
+value           "Tell me."
+
+[section-29]
 key             "reinforce-engage"
 value           "Come on! Raise your hand and let's start the exercise."

--- a/modules/managerTUG/app/conf/speak-it.ini
+++ b/modules/managerTUG/app/conf/speak-it.ini
@@ -1,5 +1,5 @@
 [general]
-num-sections    29
+num-sections    30
 
 [section-0]
 key             "ouch"
@@ -91,7 +91,7 @@ value           "Mi dispiace, non so rispondere a questa domanda."
 
 [section-22]
 key             "questions"
-value           "Tutto chiaro?"
+value           "Se vuoi farmi una domanda, per favore tieni la mano alzata."
 
 [section-23]
 key             "line"
@@ -114,5 +114,9 @@ key             "line-crossed"
 value           "Ben fatto! Hai superato la linea sul pavimento."
 
 [section-28]
+key             "asking"
+value           "Dimmi pure."
+
+[section-29]
 key             "reinforce-engage"
 value           "Coraggio! Alza la mano e cominciamo l'esercizio."

--- a/modules/managerTUG/managerTUG.xml
+++ b/modules/managerTUG/managerTUG.xml
@@ -19,6 +19,12 @@
     <param default="0.3" desc="Threshold on the distance between foot and finish line [m].">finish-line-thresh</param>
     <param default="0.2" desc="Threshold on the speed of the shoulder center height [m/s].">standing-thresh</param>
     <param default="(1.5 -3.0 110.0)" desc="Robot initial pose (x,y,theta) wrt world frame when starting the TUG.">starting-pose</param>
+    <param default="3.0" desc="Time ctpService takes to complete the pointing movement.">pointing-time</param>
+    <param default="(-10.0,20.0,-10.0,35.0,0.0,0.030,0.0,0.0)" desc="List of joint positions for reaching arm home position (deg). Provided to ctpService.">pointing-home</param>
+    <param default="(70.0,12.0,-10.0,10.0,0.0,0.050,0.0,0.0)" desc="List of joint positions for pointing at the chair (deg). Provided to ctpService.">pointing-start</param>
+    <param default="(35.0,12.0,-10.0,10.0,0.0,0.050,0.0,0.0)" desc="List of joint positions for pointing at the finish line (deg). Provided to ctpService.">pointing-finish</param>
+    <param default="0.6" desc="Threshold on the y distance between elbow and elbow, to detect if the arm is raised (normalized).">arm-thresh</param>
+    <param default="true" desc="If true, the module detects if the hand is raised for triggering speech.">detect-hand-up</param>
   </arguments>
 
   <authors>


### PR DESCRIPTION
This PR introduces a new modality to detect if the hand is raised, which relies on the normalized 3D skeleton and applies a threshold on the distance hand - elbow, computed on the z axis (with respect to the start-line).
I introduced the flag `detect-hand-up` in `managerTUG`:
- if set to true, `managerTUG` is in charge of detecting if the hand is raised using the 3D skeleton;
- if set to false, we can rely on `humanStructure`, using 2D skeleton. I added a check in `humanStructure`, in order to avoid to send commands to `googleSpeech` if the trigger port is not connected.