### PR TITLE
Integrated skeletonLocker in TUG 

### DIFF
--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -52,6 +52,11 @@
     </module>
 
     <module>
+       <name>skeletonLocker</name>
+       <node>r1-console-linux</node>
+    </module>
+
+    <module>
        <name>attentionManager</name>
        <parameters>--frame world</parameters>
        <node>r1-console-linux</node>
@@ -97,7 +102,6 @@
 
     <module>
         <name>managerTUG</name>
-        <parameters>--standing-thresh 0.2 --finish-line-thresh 0.3</parameters>
         <node>r1-console-linux</node>
     </module>
 
@@ -211,6 +215,18 @@
 
     <connection>
         <from>/opc/broadcast:o</from>
+        <to>/skeletonLocker/opc:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/skeletonLocker/opc:rpc</from>
+        <to>/opc/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/opc/broadcast:o</from>
         <to>/attentionManager/opc:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
@@ -288,12 +304,6 @@
     </connection>
 
     <connection>
-        <from>/skeletonRetriever/viewer:o</from>
-        <to>/skeletonViewer:i</to>
-        <protocol>fast_tcp</protocol>
-    </connection>
-
-    <connection>
         <from>/robotSkeletonPublisher/opc:rpc</from>
         <to>/opc/rpc</to>
         <protocol>fast_tcp</protocol>
@@ -307,6 +317,12 @@
 
     <connection>
         <from>/robotSkeletonPublisher/viewer:o</from>
+        <to>/skeletonViewer:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/skeletonLocker/viewer:o</from>
         <to>/skeletonViewer:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
@@ -350,6 +366,12 @@
     <connection>
         <from>/managerTUG/navigation:rpc</from>
         <to>/navController/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/locker:rpc</from>
+        <to>/skeletonLocker/rpc</to>
         <protocol>fast_tcp</protocol>
     </connection>
 

--- a/modules/skeletonLocker/src/idl.thrift
+++ b/modules/skeletonLocker/src/idl.thrift
@@ -23,4 +23,12 @@ service skeletonLocker_IDL
     * @return true/false on success/failure.
     */
    bool set_skeleton_tag(1:string tag)
+
+   /**
+    * Remove locked skeleton.
+    * @return true/false on success/failure.
+    */
+   bool remove_locked()
+
 }
+

--- a/modules/skeletonLocker/src/main.cpp
+++ b/modules/skeletonLocker/src/main.cpp
@@ -104,6 +104,17 @@ public:
     }
 
     /****************************************************************/
+    bool remove_locked() override
+    {
+        lock_guard<mutex> lg(mtx);
+        skeleton_tag=tag_locked="";
+        if (locked->opc_id>=0)
+            return opcDel(*locked);
+
+        return false;
+    }
+
+    /****************************************************************/
     bool set_skeleton_tag(const string &tag) override
     {
         lock_guard<mutex> lg(mtx);


### PR DESCRIPTION
This PR modifies `managerTUG` in order to lock a skeleton and engage it.
When the command `start` is provided to `managerTUG` , `attentionManager` is set in autonomous mode and starts seeking for skeletons. When a skeleton is found, `managerTUG` asks `skeletonLocker` to lock it and this skeleton is used during the interaction. 

I added an additional service in `skeletonLocker` to remove the locked skeleton from `opc`: if a skeleton is disengaged or we stop the interaction, the locked skeleton is removed from `opc`; for a new interaction, a new locked skeleton is created. 