### PR TITLE
Fixed skeletonLocker

### DIFF
--- a/app/gazebo/tug/tug-scenario.world
+++ b/app/gazebo/tug/tug-scenario.world
@@ -16,9 +16,9 @@
     <!-- R1 -->
     <model name='SIM_CER_ROBOT'>
       <include>
-    	<uri>model://cer</uri>
+        <uri>model://cer_320x240</uri>
       </include>
-      <pose>6.5 1.5 0.16 0.0 0.0 3.14</pose>
+      <pose>5.0 1.5 0.16 0.0 0.0 -2.80</pose>
     </model>
 
     <!-- Aruco lines -->

--- a/app/scripts/AssistiveRehab-TUG_SIM.xml.template
+++ b/app/scripts/AssistiveRehab-TUG_SIM.xml.template
@@ -122,7 +122,7 @@
 
     <module>
        <name>navController</name>
-       <parameters>--velocity-angular-saturation 15.0 --distance-target 6.0 --velocity-linear-magnitude 0.6</parameters>
+       <parameters>--velocity-angular-saturation 15.0 --distance-target 5.5 --velocity-linear-magnitude 0.6</parameters>
        <dependencies>
          <port timeout="15">/baseControl/rpc</port>
          <port timeout="15">/baseControl/odometry:o</port>
@@ -171,7 +171,7 @@
 
     <module>
         <name>managerTUG</name>
-       <parameters>--simulation true --starting-pose "(1.5 -6.0 110.0)" --standing-thresh 0.025 --finish-line-thresh 0.3</parameters>
+       <parameters>--simulation true --standing-thresh 0.025 --finish-line-thresh 0.3</parameters>
         <node>localhost</node>
     </module>
 
@@ -378,12 +378,6 @@
         <from>/yarpOpenPose/image:o</from>
         <to>/viewer/skeleton</to>
         <protocol>mjpeg</protocol>
-    </connection>
-
-    <connection>
-        <from>/skeletonRetriever/viewer:o</from>
-        <to>/skeletonViewer:i</to>
-        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>

--- a/modules/managerTUG/app/conf/config-en.ini
+++ b/modules/managerTUG/app/conf/config-en.ini
@@ -11,5 +11,7 @@ pointing-finish           (35.0 12.0 -10.0 10.0 0.0 0.050 0.0 0.0)
 detect-hand-up            false
 arm-thresh                0.6
 simulation                false
+lock                      true
 min-timeout               1.0
 max-timeout               10.0
+target-sim                (4.5 0.0 0.0)

--- a/modules/managerTUG/app/conf/config-it.ini
+++ b/modules/managerTUG/app/conf/config-it.ini
@@ -11,5 +11,7 @@ pointing-finish           (35.0 12.0 -10.0 10.0 0.0 0.050 0.0 0.0)
 detect-hand-up            false
 arm-thresh                0.6
 simulation                false
+lock                      true
 min-timeout               1.0
 max-timeout               10.0
+target-sim                (4.5 0.0 0.0)

--- a/modules/managerTUG/src/main.cpp
+++ b/modules/managerTUG/src/main.cpp
@@ -962,6 +962,26 @@ class Manager : public RFModule, public managerTUG_IDL
             yError()<<"Not connected";
             return false;
         }
+        if (simulation)
+        {
+            Bottle cmd,rep;
+            cmd.addString("getModelPos");
+            cmd.addString("SIM_CER_ROBOT");
+            if (gazeboPort.write(cmd,rep))
+            {
+                Property prop(rep.get(0).toString().c_str());
+                Bottle *model=prop.find("SIM_CER_ROBOT").asList();
+                if (Bottle *pose=model->find("pose_world").asList())
+                {
+                    if(pose->size()>=7)
+                    {
+                        starting_pose[0]=pose->get(0).asDouble();
+                        starting_pose[1]=pose->get(1).asDouble();
+                        starting_pose[2]=pose->get(6).asDouble()*(180.0/M_PI);
+                    }
+                }
+            }
+        }
         state=State::idle;
         bool ret=false;
         if (go_to(starting_pose,true))
@@ -1157,16 +1177,13 @@ class Manager : public RFModule, public managerTUG_IDL
                 return false;
             }
         }
-
         set_target(target_sim[0],target_sim[1],target_sim[2]);
-
         state=State::idle;
         interrupting=false;
         world_configured=false;
         ok_go=false;
         connected=false;
         t0=tstart=Time::now();
-
         return true;
     }
 

--- a/modules/skeletonLocker/src/main.cpp
+++ b/modules/skeletonLocker/src/main.cpp
@@ -235,7 +235,6 @@ public:
                     locked->skeleton->setTag(tag_locked);
                     locked->opc_id=opc_id_locked;
                     t=Time::now();
-                    opcSet(*locked);
                 }
             }
 
@@ -257,6 +256,7 @@ public:
             double r=(max_radius-radius)*tanh(alpha*locked->timer)+radius;
             locked->radius=(r<=max_radius?r:max_radius);
         }
+        opcSet(*locked);
         t0=Time::now();
 
         viewerUpdate();


### PR DESCRIPTION
This PR fixes `skeletonLocker`: the first skeleton locked was only added to the `opc` and not set.
Since `attentionManager` reads from `opc`, it was always focusing on the same initial point, which was not coherent with the movement of the human model.
The PR also moves the robot position closer to the chair.