### PR TITLE
Improve feedback

### DIFF
--- a/app/gazebo/tug/plugins/tuginterface/interface/include/tugserver.h
+++ b/app/gazebo/tug/plugins/tuginterface/interface/include/tugserver.h
@@ -85,6 +85,12 @@ public:
     virtual bool pause(const double time);
 
     /**
+     * Returns true is actor is active.
+     * @return returns true / false if actor is active / paused.
+     */
+    virtual bool isActive();
+
+    /**
      * Play from last animation.
      * @param complete if true, the whole script is played starting from last stop.
      * @return returns true / false on success / failure.

--- a/app/gazebo/tug/plugins/tuginterface/interface/src/tugserver.cpp
+++ b/app/gazebo/tug/plugins/tuginterface/interface/src/tugserver.cpp
@@ -59,6 +59,12 @@ bool TugServer::pause(const double time)
 }
 
 /****************************************************************/
+bool TugServer::isActive()
+{
+    return actor->IsActive();
+}
+
+/****************************************************************/
 bool TugServer::playFromLast(const bool complete)
 {
     yInfo()<<"Playing from last";

--- a/app/gazebo/tug/plugins/tuginterface/thrift/tuginterface_rpc.thrift
+++ b/app/gazebo/tug/plugins/tuginterface/thrift/tuginterface_rpc.thrift
@@ -73,6 +73,12 @@ service TugInterfaceServer
     bool pause(1: double time=0.0);
 
     /**
+     * Returns true is actor is active.
+     * @return returns true / false if actor is active / paused.
+     */
+    bool isActive();
+
+    /**
      * Play from last animation.
      * @param complete if true, the whole script is played starting from last stop.
      * @return returns true / false on success / failure.

--- a/app/scripts/AssistiveRehab-TUG_SIM.xml.template
+++ b/app/scripts/AssistiveRehab-TUG_SIM.xml.template
@@ -171,7 +171,7 @@
 
     <module>
         <name>managerTUG</name>
-       <parameters>--simulation true --standing-thresh 0.025 --finish-line-thresh 0.3</parameters>
+       <parameters>--simulation true</parameters>
         <node>localhost</node>
     </module>
 

--- a/modules/managerTUG/app/conf/config-en.ini
+++ b/modules/managerTUG/app/conf/config-en.ini
@@ -1,8 +1,6 @@
 name                      managerTUG
 period                    0.1
 speak-file                speak-en.ini
-finish-line-thresh        0.2
-standing-thresh           0.2
 starting-pose             (1.5 -3.0 110.0)
 pointing-time             3.0
 pointing-home             (-10.0 20.0 -10.0 35.0 0.0 0.030 0.0 0.0) 

--- a/modules/managerTUG/app/conf/config-it.ini
+++ b/modules/managerTUG/app/conf/config-it.ini
@@ -1,8 +1,6 @@
 name                      managerTUG
 period                    0.1
 speak-file                speak-it.ini
-finish-line-thresh        0.2
-standing-thresh           0.2
 starting-pose             (1.5 -3.0 110.0)
 pointing-time             3.0
 pointing-home             (-10.0 20.0 -10.0 35.0 0.0 0.030 0.0 0.0) 

--- a/modules/managerTUG/managerTUG.xml
+++ b/modules/managerTUG/managerTUG.xml
@@ -16,8 +16,6 @@
     <param default="managerTUG" desc="Name of the module. All the open ports will be tagged with the prefix /module_name.">module_name</param>
     <param default="0.1" desc="Periodicity of the module.">period</param>
     <param default="speak-it" desc="Configuration file name for the speak.">speak-file</param>
-    <param default="0.2" desc="Threshold on the distance between foot and finish line [m].">finish-line-thresh</param>
-    <param default="0.2" desc="Threshold on the speed of the shoulder center height [m/s].">standing-thresh</param>
     <param default="(1.5 -3.0 110.0)" desc="Robot initial pose (x,y,theta) wrt world frame when starting the TUG.">starting-pose</param>
     <param default="3.0" desc="Time ctpService takes to complete the pointing movement.">pointing-time</param>
     <param default="(-10.0,20.0,-10.0,35.0,0.0,0.030,0.0,0.0)" desc="List of joint positions for reaching arm home position (deg). Provided to ctpService.">pointing-home</param>

--- a/modules/managerTUG/src/main.cpp
+++ b/modules/managerTUG/src/main.cpp
@@ -1710,14 +1710,12 @@ class Manager : public RFModule, public managerTUG_IDL
                     params_set=true;
                 }
             }
-
             if (Bottle *motionRes=rep.get(0).find("step_0").asList())
             {
                 double speed=motionRes->find("speed").asDouble();
                 answer_manager->setSpeed(speed);
                 yInfo()<<"Human moving at"<<speed<<"m/s";
             }
-
             human_state=rep.get(0).find("human-state").asString();
             yInfo()<<"Human state"<<human_state;
         }

--- a/modules/managerTUG/src/main.cpp
+++ b/modules/managerTUG/src/main.cpp
@@ -270,6 +270,7 @@ class AnswerManager: public BufferedPort<Bottle>
     RpcClient *gazeboPort;
     bool replied,silent;
     double time;
+    double speed,speed_medium,speed_high;
     mutex mtx;
 
 public:
@@ -292,6 +293,13 @@ public:
     /********************************************************/
     ~AnswerManager()
     {
+    };
+
+    /********************************************************/
+    void setExerciseParams(const double &distance, const double &time_high, const double &time_medium)
+    {
+        speed_high=(2.0*distance)/time_high;
+        speed_medium=(2.0*distance)/time_medium;
     }
 
     /********************************************************/
@@ -391,9 +399,9 @@ public:
     }
 
     /********************************************************/
-    void setTime(const double &t)
+    void setSpeed(const double &s)
     {
-        this->time=t;
+        this->speed=s;
     }
 
     /********************************************************/
@@ -407,15 +415,15 @@ public:
             {
                 if(keyword=="feedback")
                 {
-                    if(time<=10.0)
+                    if(speed>=speed_high)
                     {
                         keyword+="-high";
                     }
-                    else if(time<=30.0)
+                    else if(speed<speed_high && speed>=speed_medium)
                     {
                         keyword+="-medium";
                     }
-                    else if(time>=30.0)
+                    else if(speed<speed_medium)
                     {
                         keyword+="-low";
                     }
@@ -610,12 +618,13 @@ class Manager : public RFModule, public managerTUG_IDL
     string module_name;
     string speak_file;
     double period;
-    double finish_line_thresh,standing_thresh,pointing_time,arm_thresh;
+    double pointing_time,arm_thresh;
     bool detect_hand_up;
     Vector starting_pose,pointing_home,pointing_start,pointing_finish;
     double min_timeout,max_timeout;
     bool simulation,lock;
     Vector target_sim;
+    string human_state;
 
     const int ok=Vocab::encode("ok");
     const int fail=Vocab::encode("fail");
@@ -628,7 +637,7 @@ class Manager : public RFModule, public managerTUG_IDL
     unordered_map<string,int> speak_count_map;
     bool interrupting;
     mutex mtx;
-    bool start_ex,ok_go,connected;
+    bool start_ex,ok_go,connected,params_set;
 
     Vector finishline_pose;
     double line_length;
@@ -1045,8 +1054,6 @@ class Manager : public RFModule, public managerTUG_IDL
         module_name=rf.check("name",Value("managerTUG")).asString();
         period=rf.check("period",Value(0.1)).asDouble();
         speak_file=rf.check("speak-file",Value("speak-it")).asString();
-        finish_line_thresh=rf.check("finish-line-thresh",Value(0.2)).asDouble();
-        standing_thresh=rf.check("standing-thresh",Value(0.2)).asDouble();
         arm_thresh=rf.check("arm-thresh",Value(0.6)).asDouble();
         detect_hand_up=rf.check("detect-hand-up",Value(false)).asBool();
         min_timeout=rf.check("min-timeout",Value(1.0)).asDouble();
@@ -1118,7 +1125,6 @@ class Manager : public RFModule, public managerTUG_IDL
                 }
             }
         }
-
         this->setName(module_name.c_str());
 
         if (!load_speak(rf.getContext(),speak_file))
@@ -1183,6 +1189,7 @@ class Manager : public RFModule, public managerTUG_IDL
         world_configured=false;
         ok_go=false;
         connected=false;
+        params_set=false;
         t0=tstart=Time::now();
         return true;
     }
@@ -1688,21 +1695,77 @@ class Manager : public RFModule, public managerTUG_IDL
             }
         }
 
-        answer_manager->setTime(Time::now()-tstart);
+        Bottle cmd,rep;
+        cmd.addString("getState");
+        if (analyzerPort.write(cmd,rep))
+        {
+            if (!params_set)
+            {
+                if (Bottle *exerciseParams=rep.get(0).find("exercise").asList())
+                {
+                    double distance=exerciseParams->find("distance").asDouble();
+                    double time_high=exerciseParams->find("time-high").asDouble();
+                    double time_medium=exerciseParams->find("time-medium").asDouble();
+                    answer_manager->setExerciseParams(distance,time_high,time_medium);
+                    params_set=true;
+                }
+            }
+
+            if (Bottle *motionRes=rep.get(0).find("step_0").asList())
+            {
+                double speed=motionRes->find("speed").asDouble();
+                answer_manager->setSpeed(speed);
+                yInfo()<<"Human moving at"<<speed<<"m/s";
+            }
+
+            human_state=rep.get(0).find("human-state").asString();
+            yInfo()<<"Human state"<<human_state;
+        }
+
         if (state==State::assess_standing)
         {
             //check if the person stands up
-            Bottle cmd,rep;
-            cmd.addString("isStanding");
-            cmd.addDouble(standing_thresh);
-            if (analyzerPort.write(cmd,rep))
+            if(human_state=="standing")
             {
-                if(rep.get(0).asVocab()==ok)
+                yInfo()<<"Person standing";
+                state=State::assess_crossing;
+                encourage_cnt=0;
+                t0=Time::now();
+            }
+            else
+            {
+                if((Time::now()-t0)>20.0)
                 {
-                    yInfo()<<"Person standing";
-                    state=State::assess_crossing;
-                    encourage_cnt=0;
-                    t0=Time::now();
+                    if(++encourage_cnt<=1)
+                    {
+                        speak("encourage",false);
+                        t0=Time::now();
+                    }
+                    else
+                    {
+                        state=State::not_passed;
+                    }
+                }
+            }
+        }
+
+        if (state==State::assess_crossing)
+        {
+            if(human_state=="crossed")
+            {
+                yInfo()<<"Line crossed!";
+                state=State::line_crossed;
+                speak("line-crossed",true);
+                encourage_cnt=0;
+                t0=Time::now();
+            }
+            else
+            {
+                if(human_state=="sitting")
+                {
+                    yInfo()<<"Test finished but line not crossed";
+                    speak("not-crossed",false);
+                    state=State::not_passed;
                 }
                 else
                 {
@@ -1711,62 +1774,11 @@ class Manager : public RFModule, public managerTUG_IDL
                         if(++encourage_cnt<=1)
                         {
                             speak("encourage",false);
-                            speak("remind-questions",false);
                             t0=Time::now();
                         }
                         else
                         {
                             state=State::not_passed;
-                        }
-                    }
-                }
-            }
-        }
-
-        if (state==State::assess_crossing)
-        {
-            Bottle cmd,rep;
-            cmd.addString("hasCrossedFinishLine");
-            cmd.addDouble(finish_line_thresh);
-            if (analyzerPort.write(cmd,rep))
-            {
-                if(rep.get(0).asVocab()==ok)
-                {
-                    yInfo()<<"Line crossed!";
-                    state=State::line_crossed;
-                    speak("line-crossed",true);
-                    encourage_cnt=0;
-                    t0=Time::now();
-                }
-                else
-                {
-                    cmd.clear();
-                    rep.clear();
-                    cmd.addString("isSitting");
-                    cmd.addDouble(standing_thresh);
-                    if (analyzerPort.write(cmd,rep))
-                    {
-                        if(rep.get(0).asVocab()==ok)
-                        {
-                            yInfo()<<"Test finished but line not crossed";
-                            speak("not-crossed",false);
-                            state=State::not_passed;
-                        }
-                        else
-                        {
-                            if((Time::now()-t0)>20.0)
-                            {
-                                if(++encourage_cnt<=1)
-                                {
-                                    speak("encourage",false);
-                                    speak("remind-questions",false);
-                                    t0=Time::now();
-                                }
-                                else
-                                {
-                                    state=State::not_passed;
-                                }
-                            }
                         }
                     }
                 }
@@ -1776,33 +1788,26 @@ class Manager : public RFModule, public managerTUG_IDL
         if (state==State::line_crossed)
         {
             //detect when the person seats down
-            Bottle cmd,rep;
-            cmd.addString("isSitting");
-            cmd.addDouble(standing_thresh);
-            if (analyzerPort.write(cmd,rep))
+            if(human_state=="sitting")
             {
-                if(rep.get(0).asVocab()==ok)
+                state=State::finished;
+                t=Time::now()-tstart;
+                yInfo()<<"Stop!";
+            }
+            else
+            {
+                if((Time::now()-t0)>30.0)
                 {
-                    state=State::finished;
-                    t=Time::now()-tstart;
-                    yInfo()<<"Stop!";
-                }
-                else
-                {
-                    if((Time::now()-t0)>20.0)
+                    if(++encourage_cnt<=1)
                     {
-                        if(++encourage_cnt<=1)
-                        {
-                            speak("encourage",false);
-                            speak("remind-questions",false);
-                            t0=Time::now();
-                        }
-                        else
-                        {
-                            state=State::not_passed;
-                            t=Time::now()-tstart;
-                            yInfo()<<"Not passed in"<<t<<"seconds";
-                        }
+                        speak("encourage",false);
+                        t0=Time::now();
+                    }
+                    else
+                    {
+                        state=State::not_passed;
+                        t=Time::now()-tstart;
+                        yInfo()<<"Not passed in"<<t<<"seconds";
                     }
                 }
             }

--- a/modules/motionAnalyzer/app/conf/tug.ini
+++ b/modules/motionAnalyzer/app/conf/tug.ini
@@ -1,5 +1,10 @@
 [general]
 type                           test
+finish-line-thresh             0.3
+standing-thresh                0.025
+distance                       3.0
+time-high                      10.0
+time-medium                    20.0
 vel_estimator_N                100
 vel_estimator_D                5.0
 

--- a/modules/motionAnalyzer/include/Exercise.h
+++ b/modules/motionAnalyzer/include/Exercise.h
@@ -54,6 +54,7 @@ public:
     virtual void setFeedbackParams(const yarp::os::Property &p) = 0;
     yarp::os::Property getFeedbackParams() const { return feedparams; }
     virtual yarp::sig::Matrix getFeedbackThresholds() = 0;
+    virtual yarp::os::Property publish() = 0;
 
     void print(std::ostream &os=std::cout);
 
@@ -78,6 +79,7 @@ public:
 
     void setFeedbackParams(const yarp::os::Property &p) override;
     yarp::sig::Matrix getFeedbackThresholds() override;
+    yarp::os::Property publish() override {;}
 
 };
 
@@ -155,17 +157,21 @@ public:
 
     void setFeedbackParams(const yarp::os::Property &p) override;
     yarp::sig::Matrix getFeedbackThresholds() override;
+    yarp::os::Property publish() override {;}
 
 };
 
 class Tug : public Exercise
 {
+    double finishline_thresh,standing_thresh,distance,time_high,time_medium;
 
 public:
-    Tug();
+    Tug(const double &finishline_thresh, const double &standing_thresh, const double &distance,
+        const double &time_high,const double &time_low);
 
     void setFeedbackParams(const yarp::os::Property &p) override {;}
     yarp::sig::Matrix getFeedbackThresholds() override {;}
+    yarp::os::Property publish();
 
 };
 

--- a/modules/motionAnalyzer/include/Manager.h
+++ b/modules/motionAnalyzer/include/Manager.h
@@ -42,6 +42,9 @@ class Manager : public yarp::os::RFModule,
     yarp::os::RpcClient actionPort;
     yarp::os::BufferedPort<yarp::os::Bottle> scopePort;
 
+    enum class State { idle, sitting, standing, crossed } state;
+    bool standing;
+
     yarp::os::ResourceFinder *rf;
 
     std::map<std::string,Exercise*> motion_repertoire;
@@ -76,10 +79,12 @@ class Manager : public yarp::os::RFModule,
     std::mutex mtx;
     yarp::sig::Vector shoulder_height;
     iCub::ctrl::AWLinEstimator *lin_est_shoulder;
-    double shoulder_center_height_vel;
+    double shoulder_center_height_vel,standing_thresh,finishline_thresh;
     std::vector<double> line_pose;
     yarp::sig::Matrix world_frame;
     yarp::sig::Vector num,den;
+
+    yarp::os::Bottle bResult;
 
     bool loadMotionList(yarp::os::ResourceFinder &rf);
     yarp::os::Property loadFeedbackList(const yarp::os::Bottle &bExercise, const std::string &ex_tag);
@@ -105,10 +110,8 @@ class Manager : public yarp::os::RFModule,
     bool setTemplateTag(const std::string &template_tag) override;
     bool mirrorTemplate(const bool robot_skeleton_mirror) override;
     bool stopFeedback() override;
-    bool isStanding(const double standing_thresh) override;
-    bool isSitting(const double standing_thresh) override;
-    bool hasCrossedFinishLine(const double finishline_thresh) override;
     bool setLinePose(const std::vector<double> &line_pose) override;
+    yarp::os::Property getState() override;
 
     bool writeStructToMat(const std::string& name, const std::vector< std::vector< std::pair<std::string,yarp::sig::Vector> > >& keypoints_skel, mat_t *matfp);
     bool writeStructToMat(const std::string& name, const Exercise *ex, mat_t *matfp);
@@ -122,6 +125,10 @@ class Manager : public yarp::os::RFModule,
     void print(const std::vector< std::vector< std::pair<std::string,yarp::sig::Vector> > >& keypoints_skel);
 
     void getSkeleton();
+    bool isStanding();
+    bool isSitting();
+    bool hasCrossedFinishLine();
+    yarp::os::Property publishState();
     bool attach(yarp::os::RpcServer &source) override;
 
 public:

--- a/modules/motionAnalyzer/include/Manager.h
+++ b/modules/motionAnalyzer/include/Manager.h
@@ -129,6 +129,10 @@ class Manager : public yarp::os::RFModule,
     bool isSitting();
     bool hasCrossedFinishLine();
     yarp::os::Property publishState();
+    void updateState();
+    void estimate();
+    void writeMatio();
+    void reset();
     bool attach(yarp::os::RpcServer &source) override;
 
 public:

--- a/modules/motionAnalyzer/include/Processor.h
+++ b/modules/motionAnalyzer/include/Processor.h
@@ -98,7 +98,7 @@ public:
     void reset() override;
 
     std::pair< std::deque<double>,std::deque<int> > findPeaks(const yarp::sig::Vector &d,
-                                                              const double &minv, double &tlast);
+                                                              const double &minv);
     void estimateSpatialParams(const double &dist,const double &width);
     double estimateCadence();
     double estimateSpeed();

--- a/modules/motionAnalyzer/motionAnalyzer.xml
+++ b/modules/motionAnalyzer/motionAnalyzer.xml
@@ -116,6 +116,29 @@
 
    @subsubsection sec-tug tug.ini
    This section describes the conf file tug.ini.
+   The `general` section includes the following parameters:
+
+   \code
+   [general]
+   type                           test
+   finish-line-thresh             0.3
+   standing-thresh                0.025
+   distance                       3.0
+   time-high                      10.0
+   time-medium                    20.0
+   vel_estimator_N                100
+   vel_estimator_D                5.0
+   \endcode
+
+   with:
+   - `finish-line-thresh`: threshold on the distance between foot and finish line [m];
+   - `standing-thresh`: threshold on the speed of the shoulder center height [m/s];
+   - `distance`: the distance to travel [m];
+   - `time-high`: the time the user should take to travel `distance` and get a high score [s];
+   - `time-high`: the time the user should take to travel `distance` and get a medium score [s];
+   - `vel_estimator_N`: maximum length of the window used to estimate the shoulder height speed;
+   - `vel_estimator_D`: threshold applied to the linear estimator.
+
    For this exercise we compute the range of motion of six joints and the step parameters, specifically step length, step width, cadence and speed.
    The sections describing the range of motion metrics are the same defined in \ref sec-abduction.
    There is an additional section for extracting the step parameters:

--- a/modules/motionAnalyzer/src/Exercise.cpp
+++ b/modules/motionAnalyzer/src/Exercise.cpp
@@ -377,8 +377,27 @@ void ReachingLeft::setFeedbackParams(const Property &p)
 /************************/
 /*         TUG          */
 /************************/
-Tug::Tug()
+Tug::Tug(const double &finishline_thresh, const double &standing_thresh, const double &distance, const double &time_high, const double &time_medium)
 {
     name=ExerciseTag::tug;
     type=ExerciseType::test;
+    this->finishline_thresh=finishline_thresh;
+    this->standing_thresh=standing_thresh;
+    this->distance=distance;
+    this->time_high=time_high;
+    this->time_medium=time_medium;
 }
+
+yarp::os::Property Tug::publish()
+{
+    Property p;
+//    Property &p_group=p.addGroup("exercise");
+    p.put("name",name);
+    p.put("distance",distance);
+    p.put("finish-line-thresh",finishline_thresh);
+    p.put("standing-thresh",standing_thresh);
+    p.put("time-high",time_high);
+    p.put("time-medium",time_medium);
+    return p;
+}
+

--- a/modules/motionAnalyzer/src/Processor.cpp
+++ b/modules/motionAnalyzer/src/Processor.cpp
@@ -315,13 +315,11 @@ void Step_Processor::estimateSpatialParams(const double &dist,const double &widt
         {
             steplen/=stepvec.size();
         }
-
         int laststrike=stepvec.size()>numsteps ? strikes.back() : 0.0;
         stepwidth=feetwidth[laststrike];
         numsteps=(int)strikes.size();
     }
 }
-
 
 /********************************************************/
 double Step_Processor::estimateCadence()
@@ -351,10 +349,6 @@ pair<deque<double>,deque<int>> Step_Processor::findPeaks(const Vector &d, const 
             {
                 val.pop_front();
             }
-            if (idx.size()>step_window)
-            {
-                idx.pop_front();
-            }
         }
         else if(i==d.size() && d[i]>=d[i-1] && d[i]>minv)
         {
@@ -364,10 +358,6 @@ pair<deque<double>,deque<int>> Step_Processor::findPeaks(const Vector &d, const 
             {
                 val.pop_front();
             }
-            if (idx.size()>step_window)
-            {
-                idx.pop_front();
-            }
         }
         else if(d[i]>=d[i-1] && d[i]>=d[i+1] && d[i]>minv)
         {
@@ -376,10 +366,6 @@ pair<deque<double>,deque<int>> Step_Processor::findPeaks(const Vector &d, const 
             if (val.size()>step_window)
             {
                 val.pop_front();
-            }
-            if (idx.size()>step_window)
-            {
-                idx.pop_front();
             }
         }
     }

--- a/modules/motionAnalyzer/src/Processor.cpp
+++ b/modules/motionAnalyzer/src/Processor.cpp
@@ -298,10 +298,14 @@ void Step_Processor::estimateSpatialParams(const double &dist,const double &widt
     tdist.push_back(Time::now());
 
     pair<deque<double>,deque<int>> step_params;
-    double tlast;
-    step_params=findPeaks(feetdist,step_thresh,tlast);
+    double tlast=0.0;
+    step_params=findPeaks(feetdist,step_thresh);
     deque<double> stepvec=step_params.first;
     deque<int> strikes=step_params.second;
+    if (strikes.size()>0)
+    {
+        tlast=tdist[strikes.back()];
+    }
 
     steplen=0.0;
     stepwidth=0.0;
@@ -334,45 +338,35 @@ double Step_Processor::estimateSpeed()
 }
 
 /********************************************************/
-pair<deque<double>,deque<int>> Step_Processor::findPeaks(const Vector &d, const double &minv,
-                                                         double &tlast)
+pair<deque<double>,deque<int>> Step_Processor::findPeaks(const Vector &d, const double &minv)
 {
     deque<double> val;
     deque<int> idx;
     for(int i=0; i<d.size(); i++)
     {
-        if(i==0 && d[i]>=d[i+1] && d[i]>minv)
+        if (d[i]<=minv)
         {
-            val.push_back(d[i]);
-            idx.push_back(i);
-            if (val.size()>step_window)
-            {
-                val.pop_front();
-            }
+            continue;
         }
-        else if(i==d.size() && d[i]>=d[i-1] && d[i]>minv)
+        if(i==0 && d[i]>=d[i+1])
         {
             val.push_back(d[i]);
             idx.push_back(i);
-            if (val.size()>step_window)
-            {
-                val.pop_front();
-            }
         }
-        else if(d[i]>=d[i-1] && d[i]>=d[i+1] && d[i]>minv)
+        else if(i==d.size() && d[i]>=d[i-1])
         {
             val.push_back(d[i]);
             idx.push_back(i);
-            if (val.size()>step_window)
-            {
-                val.pop_front();
-            }
+        }
+        else if(d[i]>=d[i-1] && d[i]>=d[i+1])
+        {
+            val.push_back(d[i]);
+            idx.push_back(i);
         }
     }
-    tlast=0.0;
-    if (idx.size()>0)
+    if (val.size()>step_window)
     {
-        tlast=tdist[idx.back()];
+        val.pop_front();
     }
     pair<deque<double>,deque<int>> step_params;
     step_params=make_pair(val,idx);

--- a/modules/motionAnalyzer/src/idl.thrift
+++ b/modules/motionAnalyzer/src/idl.thrift
@@ -16,6 +16,12 @@ struct Matrix { }
    yarp.includefile="yarp/sig/Matrix.h"
 )
 
+struct Property { }
+(
+   yarp.name="yarp::os::Property"
+   yarp.includefile="yarp/os/Property.h"
+)
+
 /**
  * motionAnalyzer_IDL
  *
@@ -126,30 +132,15 @@ service motionAnalyzer_IDL
    bool mirrorTemplate(1:bool robot_skeleton_mirror);
 
    /**
-   * Detect if the person is standing.
-   * @param standing_thresh threshold on the speed of the shoulder center height [m/s].
-   * @return true/false if the person is/is not standing.
-   */
-   bool isStanding(1:double standing_thresh);
-
-   /**
-   * Detect if the person is sitting.
-   * @param standing_thresh threshold on the speed of the shoulder center height [m/s].
-   * @return true/false if the person is/is not standing.
-   */
-   bool isSitting(1:double standing_thresh);
-
-   /**
-   * Detect if the finish line has been crossed.
-   * @param finishline_thresh distance between foot and finish line [m].
-   * @return true/false if the finish line has been/not been crossed.
-   */
-   bool hasCrossedFinishLine(1:double finishline_thresh);
-
-   /**
    * Set the pose of the finish line.
    * @param pose of the finish line.
    * @return true/false on success/failure.
    */
    bool setLinePose(1:list<double> line_pose);
+
+   /**
+   * Retrieve motion analysis result.
+   * @return a property-like object containing the result of the analysis.
+   */
+   Property getState();
 }

--- a/report/ProgrammaticReport-eng.ipynb
+++ b/report/ProgrammaticReport-eng.ipynb
@@ -1679,7 +1679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 138,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1698,7 +1698,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 139,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1783,7 +1783,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 140,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1802,7 +1802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 141,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/report/report-ita.ipynb
+++ b/report/report-ita.ipynb
@@ -477,7 +477,6 @@
     "    name = \"step\"\n",
     "    num = []\n",
     "    den = []\n",
-    "    step_thresh = 0.0\n",
     "    tstart = 0.0\n",
     "    tend = 0.0\n",
     "    steplen = []\n",
@@ -3893,7 +3892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
This PR improves the feedback provided to the user, assigning a score based on the following considerations:
- if the test is completed in < `10s`, the user is assigned with a _high_ score;
- if the test is completed in > `10s` and < `20s`, the user is assigned with a _medium_ score;
- if the test is completed in > `20s`, the user is associated with a _low_ score.  

_Note: these values are adopted by physiotherapists to evaluate the risk for falling of the subject._

For computing the score, we rely on the walking speed estimated while performing the test, instead of the time. This allows us to produce a low score if the person stops moving or if moving slowly. 
In any case, if the line is not crossed, the test is considered failed. 

The PR also introduces the `getState` service, which provides information about the result of the motion analysis, as:
- the exercise / test being performed and the related parameters;
- the state of the user (if standing, sitting or has crossed the line for the TUG);
- the result of the analysis (step length, width, speed).
