### PR TITLE
Handling obstacles in TUG demo

### DIFF
--- a/app/gazebo/tug/tug-scenario-obstacles.world
+++ b/app/gazebo/tug/tug-scenario-obstacles.world
@@ -1,0 +1,142 @@
+<?xml version="1.0" ?>
+<sdf version='1.6'>
+
+<world name="default">
+
+    <!-- Global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!-- Ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+   
+    <!-- R1 -->
+    <model name='SIM_CER_ROBOT'>
+      <include>
+        <uri>model://cer_320x240</uri>
+      </include>
+      <pose>5.0 1.5 0.16 0.0 0.0 -2.80</pose>
+    </model>
+
+    <!-- Aruco lines -->
+    <model name='start-line'>
+      <include>
+        <uri>model://aruco_board_start</uri>
+      </include>
+      <pose>0.5 0.0 0.0 0.0 0.0 1.59</pose>
+    </model>
+    <model name='finish-line'>
+      <include>
+        <uri>model://aruco_board_finish</uri>
+      </include>
+      <pose>3.5 0.0 0.0 0.0 0.0 1.59</pose>
+    </model>
+
+    <!-- Human model -->
+    <actor name="human">
+      <plugin name="actor_collisions_plugin" filename="libActorCollisionsPlugin.so">
+        <scaling collision="LHipJoint_LeftUpLeg_collision" scale="0.01 0.001 0.001"/>
+        <scaling collision="LeftUpLeg_LeftLeg_collision" scale="8.0 8.0 1.0"/>
+        <scaling collision="LeftLeg_LeftFoot_collision" scale="8.0 8.0 1.0"/>
+        <scaling collision="LeftFoot_LeftToeBase_collision" scale="4.0 4.0 1.5"/>
+        <scaling collision="RHipJoint_RightUpLeg_collision" scale="0.01 0.001 0.001"/>
+        <scaling collision="RightUpLeg_RightLeg_collision" scale="8.0 8.0 1.0"/>
+        <scaling collision="RightLeg_RightFoot_collision" scale="8.0 8.0 1.0"/>
+        <scaling collision="RightFoot_RightToeBase_collision" scale="4.0 4.0 1.5"/>
+      </plugin>
+      <skin>
+        <filename>stand.dae</filename>
+      </skin>
+      <animation name="stand">
+        <filename>stand.dae</filename>
+      </animation>
+      <animation name="stand_up">
+        <filename>stand_up.dae</filename>
+      </animation>
+      <animation name="sitting">
+        <filename>sitting.dae</filename>
+      </animation>
+      <animation name="walk">
+        <filename>walk.dae</filename>
+        <interpolate_x>true</interpolate_x>
+      </animation>
+      <animation name="sit_down">
+        <filename>sit_down.dae</filename>
+      </animation>
+      <script>
+        <loop>false</loop>
+        <auto_start>false</auto_start>
+        <trajectory id="0" type="stand"/>
+        <trajectory id="1" type="sit_down"/>
+        <trajectory id="2" type="sitting"/>
+        <trajectory id="3" type="stand_up"/>
+        <trajectory id="4" type="walk"/>
+        <trajectory id="5" type="sit_down"/>
+      </script>
+      <plugin name='tug_interface' filename='libgazebo_assistiverehab_tuginterface.so'>
+        <yarpConfigurationFile>model://tugInterface.ini</yarpConfigurationFile>
+      </plugin>
+    </actor>
+
+    <!-- Chair -->
+    <model name='chair'>
+      <include>
+        <uri>model://VisitorChair</uri>
+      </include>
+      <pose>-0.50 0.0 0.0 0.0 0.0 1.57</pose>
+    </model>
+
+    <!-- Nurse -->
+    <model name='nurse'>
+      <include>
+        <uri>model://Nurse</uri>
+      </include>
+      <pose>2.8 1.7 0.0 0.0 0.0 -1.8</pose>
+    </model>
+
+    <!-- Visitor -->
+    <model name='visitor'>
+      <include>
+       <uri>model://FemaleVisitorSit</uri>
+      </include>
+      <pose>8.31966 2.60415 0 0 0 -0.943788</pose>
+    </model>
+
+    <!-- Visitor chair-->
+    <model name='chair visitor'>
+      <include>
+       <uri>model://Chair</uri>
+      </include>
+      <pose>8.34326 2.98341 4e-06 -1.6e-05 -0 -2.11035</pose>
+    </model>
+
+    <!-- Walking helpers -->
+    <!-- Nested models from SDF 1.5 and gazebo 7 -->
+    <!-- <model name='walking_helpers'>
+      <static>true</static>
+      <model name='walking_cane'>
+        <include>
+          <uri>model://WalkingCane</uri>
+        </include>
+      </model>
+      <model name='walker'>
+        <include>
+          <uri>model://Walker</uri>
+        </include>
+      </model>
+    </model> -->
+
+    <!-- Camera -->
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>3.60989 -8.90123 2.55734 0 0.199643 1.5722</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+
+  </world>
+</sdf>

--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -110,6 +110,15 @@
     </module>
 
     <module>
+       <name>obstacleDetector</name>
+       <parameters></parameters>
+       <dependencies>
+         <port timeout="15">/navController/rpc</port>
+       </dependencies>
+       <node>r1-console-linux</node>
+    </module>
+
+    <module>
         <name>managerTUG</name>
         <node>r1-console-linux</node>
     </module>
@@ -142,6 +151,12 @@
         <name>yarpview</name>
         <parameters>--name /viewer/line --x 770 --y 40 --p 50 --compact</parameters>
         <node>r1-display-linux</node>
+    </module>
+
+    <module>
+       <name>yarpview</name>
+       <parameters>--name /viewer/obstacles --w 400 --h 400 --p 50 --compact</parameters>
+       <node>localhost</node>
     </module>
 
     <module>
@@ -411,6 +426,24 @@
     <connection>
         <from>/managerTUG/right_arm:rpc</from>
         <to>/ctpservice/right_arm/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/obstacleDetector/obstacle:o</from>
+        <to>/managerTUG/obstacle:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/obstacleDetector/nav:rpc</from>
+        <to>/navController/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/obstacleDetector/viewer:o</from>
+        <to>/viewer/obstacles</to>
         <protocol>fast_tcp</protocol>
     </connection>
 </application>

--- a/app/scripts/AssistiveRehab-TUG_SIM_obstacles.xml.template
+++ b/app/scripts/AssistiveRehab-TUG_SIM_obstacles.xml.template
@@ -19,7 +19,7 @@
 
     <module>
         <name>gazebo</name>
-        <parameters>tug-scenario.world</parameters>
+        <parameters>tug-scenario-obstacles.world</parameters>
         <node>localhost</node>
     </module>
 

--- a/modules/managerTUG/app/conf/config-en.ini
+++ b/modules/managerTUG/app/conf/config-en.ini
@@ -13,3 +13,5 @@ lock                      true
 min-timeout               1.0
 max-timeout               10.0
 target-sim                (4.5 0.0 0.0)
+engage-distance           (0.0 2.0)
+engage-azimuth            (80.0 110.0)

--- a/modules/managerTUG/app/conf/config-it.ini
+++ b/modules/managerTUG/app/conf/config-it.ini
@@ -13,3 +13,5 @@ lock                      true
 min-timeout               1.0
 max-timeout               10.0
 target-sim                (4.5 0.0 0.0)
+engage-distance           (0.0 2.0)
+engage-azimuth            (80.0 110.0)

--- a/modules/managerTUG/app/conf/speak-en.ini
+++ b/modules/managerTUG/app/conf/speak-en.ini
@@ -1,5 +1,6 @@
 [general]
-num-sections    34
+num-sections    37
+laser-adverb    ("behind","in front of")
 
 [section-0]
 key             "ouch"
@@ -136,3 +137,15 @@ value           "Remember to push the button if you want to ask me a question."
 [section-33]
 key             "questions-sim"
 value           "If you want to ask me a question, please push the button."
+
+[section-34]
+key             "obstacle"
+value           "There's an obstacle % me. We'll continue the exercise when the obstacle will be removed."
+
+[section-35]
+key             "reinforce-obstacle"
+value           "Please remove the obstacle. Otherwise the exercise will end here."
+
+[section-36]
+key             "stop"
+value           "Stop please."

--- a/modules/managerTUG/app/conf/speak-it.ini
+++ b/modules/managerTUG/app/conf/speak-it.ini
@@ -1,5 +1,6 @@
 [general]
-num-sections    34
+num-sections    37
+laser-adverb    ("dietro di","davanti a")
 
 [section-0]
 key             "ouch"
@@ -136,3 +137,16 @@ value           "Ricorda di premere il tasto se vuoi farmi una domanda."
 [section-33]
 key             "questions-sim"
 value           "Se vuoi farmi una domanda, per favore premi il tasto."
+
+[section-34]
+key             "obstacle"
+value           "C'e' un ostaco lo % me. Continueremo l'esercizio quando l'ostacolo sará rimosso."
+
+[section-35]
+key             "reinforce-obstacle"
+value           "Per favore, l'ostacolo va rimosso. Altrimenti concluderemo l'esercizio."
+
+[section-36]
+key             "stop"
+value           "Ferma ti per favore."
+

--- a/modules/managerTUG/managerTUG.xml
+++ b/modules/managerTUG/managerTUG.xml
@@ -28,6 +28,8 @@
     <param default="false" desc="If true, the module is configured to work simulation in gazebo.">simulation</param>
     <param default="true" desc="If true, the skeleton is locked.">lock</param>
     <param default="(4.5,0.0,0,0)" desc="Sets the target the actor has to reach during the TUG (only is simulation is true).">target-sim</param>
+    <param default="(0.0,2.0)" desc="User engaged within this distance, wrt start line (m).">engage-distance</param>
+    <param default="(80.0 110.0)" desc="User engaged within this field of view, wrt start line (degrees).">engage-azimuth</param>
   </arguments>
 
   <authors>
@@ -47,6 +49,13 @@
         <port>/managerTUG/answer:i</port>
         <description>
           Receives the answer to the question from \ref googleSpeechProcessing.
+        </description>
+    </input>
+    <input>
+        <type>Bottle</type>
+        <port>/managerTUG/obstacle:i</port>
+        <description>
+          Receives info (distance and which laser) about the presence of an obstacle from \ref obstacleDetector.
         </description>
     </input>
     <output>

--- a/modules/obstacleDetector/src/main.cpp
+++ b/modules/obstacleDetector/src/main.cpp
@@ -48,7 +48,7 @@ using namespace cv;
 /****************************************************************/
 class ObstDetector : public RFModule
 {
-    double period{0.0};
+    double period{0.1};
     string module_name{"obstacleDetector"};
     string robot{"cer"};
     PolyDriver *drv_front{nullptr},*drv_rear{nullptr};
@@ -239,13 +239,13 @@ public:
             yInfo()<<"Closest obstacle at"<<d<<"from"<<laser;
             if (d<dist_obstacle)
             {
+                Bottle &obstacle=outPort.prepare();
+                obstacle.clear();
+                obstacle.addDouble(d);
+                obstacle.addString(laser);
+                outPort.write();
                 if (getRobotState()!="idle")
                 {
-                    Bottle &obstacle=outPort.prepare();
-                    obstacle.clear();
-                    obstacle.addDouble(d);
-                    obstacle.addString(laser);
-                    outPort.write();
                     yInfo()<<"Stopping";
                     stopNav();
                 }


### PR DESCRIPTION
This PR modifies `managerTUG` in order to deal with obstacles along the path during the TUG.
If an obstacle is found within a radius of `1.5m` around the robot (within the rear and front laser FOVs), the interaction is frozen and the robot asks to remove the obstacle. The interaction does not start until the obstacle is removed (within a timeout). 

Here's a [video](https://www.youtube.com/watch?v=LHYnf3COj30) showing the functionality in `Gazebo` (low quality audio and slow interaction as it runs on my system).
The scenario includes two obstacles, that are the nurse in front of the robot and the visitor behind it:
- when the robot moves towards the finish line, the nurse falls within the obstacle detection radius and thus the interaction is frozen. To simulate that the obstacle moves away from the obstacle detection radius, I manually move it in `Gazebo` and the interaction starts again.
- when the robot starts tracking the human skeleton and moves backwards, the visitor falls within the obstacle detection radius and the interaction is frozen. Since the obstacle is not removed within the timeout, the interaction stops. 

