### PR TITLE
fixed thrift regression + random_shuffle deprecation

### DIFF
--- a/modules/attentionManager/src/main.cpp
+++ b/modules/attentionManager/src/main.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <cmath>
 #include <algorithm>
+#include <random>
 
 #include <yarp/os/all.h>
 #include <yarp/sig/all.h>
@@ -319,7 +320,9 @@ class Attention : public RFModule, public attentionManager_IDL
     {
         if (auto_mode)
         {
-            random_shuffle(begin(skeletons),end(skeletons));
+            random_device rng;
+            mt19937 urng(rng());
+            shuffle(begin(skeletons), end(skeletons), urng);
             if (auto s=find_skeleton_raised_hand())
             {
                 tag=s->getTag();

--- a/modules/faceRecognizer/faceRecognizer.thrift
+++ b/modules/faceRecognizer/faceRecognizer.thrift
@@ -21,7 +21,7 @@ service recognition_IDL
 
     /**
      * Forget a face.
-     * @param label: object name to forget. Use "all" to forget all faces.
+     * @param label: object name to forget. Use `all` to forget all faces.
      * @return true/false on success/failure.
      */
     bool forget(1:string label);


### PR DESCRIPTION
This PR fixes:
- deprecation of `random_shuffle` in C++14 (see https://meetingcpp.com/blog/items/stdrandom_shuffle-is-deprecated.html)
- Thrift regression on the use of double quotes `"` as in https://github.com/robotology/robotology-superbuild/issues/900.