### PR TITLE
Added features for computing ground truth and improving results

### DIFF
--- a/app/gazebo/tug/plugins/tuginterface/interface/include/tuginterface.h
+++ b/app/gazebo/tug/plugins/tuginterface/interface/include/tuginterface.h
@@ -38,6 +38,8 @@ private:
     physics::WorldPtr world;
     physics::ActorPtr actor;
     Velocity vel;
+    double walktime;
+    int nsteps;
     std::string starting_animation;
     yarp::sig::Matrix targets;
     std::map<double, ignition::math::Pose3d> waypoints_map;

--- a/app/gazebo/tug/plugins/tuginterface/interface/include/tugserver.h
+++ b/app/gazebo/tug/plugins/tuginterface/interface/include/tugserver.h
@@ -15,6 +15,10 @@
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/World.hh>
 #include <gazebo/physics/Actor.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/Link.hh>
+#include <gazebo/physics/Collision.hh>
+#include <gazebo/physics/BoxShape.hh>
 
 #include <include/utils.h>
 
@@ -28,6 +32,8 @@ private:
     gazebo::physics::WorldPtr world;
     gazebo::physics::ActorPtr actor;
     Velocity vel;
+    double walktime,standuptime,sitdowntime;
+    int nsteps;
     yarp::sig::Matrix targets;
     yarp::sig::Matrix line_frame;
 
@@ -53,6 +59,32 @@ public:
      * @return returns walking speed.
      */
     virtual double getSpeed();
+
+    /**
+     * Get time taken to complete the specified animation.
+     * @param animation_name name of the animation defined in the sdf.
+     * @param nsamples total number of samples for computing the average time.
+     * @return returns animation time.
+     */
+    virtual double getTime(const std::string &animation_name, const int nsamples);
+
+    /**
+     * Get walking time taken to complete the trajectory.
+     * @return returns walking time.
+     */
+    virtual double getWalkingTime();
+
+    /**
+     * Get time taken to stand up and sit down.
+     * @return returns stand up plus sit down time.
+     */
+    virtual double getStandSitTime();
+
+    /**
+     * Get number of steps.
+     * @return returns number of steps.
+     */
+    virtual int getNumSteps();
 
     /**
      * Get the list of animations associated with the actor.
@@ -98,6 +130,12 @@ public:
     virtual bool playFromLast(const bool complete);
 
     /**
+     * Get the torso front surface x coordinate.
+     * @return returns double defining the torso front surface x coordinate.
+     */
+    virtual double getTorsoFront();
+
+    /**
      * Get current animation being played.
      * @return returns string defining the current animation being played.
      */
@@ -134,7 +172,7 @@ public:
 
     void updateMap(const yarp::sig::Matrix &t);
 
-    void init(const Velocity &vel, const yarp::sig::Matrix &waypoints);
+    void init(const Velocity &vel, const yarp::sig::Matrix &waypoints, const double &walktime, const int &nsteps);
 
     void attachWorldPointer(gazebo::physics::WorldPtr p);
 

--- a/app/gazebo/tug/plugins/tuginterface/interface/include/utils.h
+++ b/app/gazebo/tug/plugins/tuginterface/interface/include/utils.h
@@ -23,7 +23,7 @@ struct Velocity
 
 void updateScript(sdf::ElementPtr &actor_sdf, const std::map<double, ignition::math::Pose3d> &m);
 
-std::map<double, ignition::math::Pose3d> createMap(const yarp::sig::Matrix &t, const Velocity &vel);
+std::map<double, ignition::math::Pose3d> createMap(const yarp::sig::Matrix &t, const Velocity &vel, double &walktime, int &nsteps);
 
 std::map<double, ignition::math::Pose3d> generateWaypoints(const Velocity &vel,
                                                            const std::map<double, ignition::math::Pose3d> &m);

--- a/app/gazebo/tug/plugins/tuginterface/interface/src/tuginterface.cpp
+++ b/app/gazebo/tug/plugins/tuginterface/interface/src/tuginterface.cpp
@@ -120,7 +120,7 @@ void TugInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
         return;
     }
 
-    waypoints_map=createMap(targets,vel);
+    waypoints_map=createMap(targets,vel,walktime,nsteps);
     waypoints_map=generateWaypoints(vel,waypoints_map);
 
     sdf::ElementPtr world_sdf=world->SDF();
@@ -143,7 +143,7 @@ void TugInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 
     m_rpcport.open(portname);
     server.yarp().attachAsServer(m_rpcport);
-    server.init(vel,targets);
+    server.init(vel,targets,walktime,nsteps);
 
     // Listen to the update event. This event is broadcast every
     // simulation iteration.

--- a/app/gazebo/tug/plugins/tuginterface/interface/src/utils.cpp
+++ b/app/gazebo/tug/plugins/tuginterface/interface/src/utils.cpp
@@ -44,15 +44,19 @@ void updateScript(sdf::ElementPtr &actor_sdf, const std::map<double, ignition::m
 }
 
 /****************************************************************/
-std::map<double, ignition::math::Pose3d> createMap(const yarp::sig::Matrix &t, const Velocity &vel)
+std::map<double, ignition::math::Pose3d> createMap(const yarp::sig::Matrix &t, const Velocity &vel, double &walktime, int &nsteps)
 {
     std::map<double, ignition::math::Pose3d> m;
     yarp::sig::Vector t0=t.getRow(0);
+    walktime=0.0;
     double duration=0.0;
+    double step_length=0.643;
+    nsteps=0;
     for (int i=0; i<t.rows(); i++)
     {
         yarp::sig::Vector t1=t.getRow(i);
         double dist=yarp::math::norm(t1.subVector(0,1)-t0.subVector(0,1));
+        nsteps+=ceil(dist/step_length);
         if (dist>0.0)
         {
             duration+=dist/vel.lin_vel;
@@ -67,6 +71,9 @@ std::map<double, ignition::math::Pose3d> createMap(const yarp::sig::Matrix &t, c
         m.insert(std::pair<double, ignition::math::Pose3d>(duration,p));
         t0=t1;
     }
+    yDebug()<<"updating map.. with duration"<<duration;
+    yDebug()<<"number of steps"<<nsteps;
+    walktime=duration;
 
     return m;
 }

--- a/app/gazebo/tug/plugins/tuginterface/thrift/tuginterface_rpc.thrift
+++ b/app/gazebo/tug/plugins/tuginterface/thrift/tuginterface_rpc.thrift
@@ -44,6 +44,32 @@ service TugInterfaceServer
     double getSpeed();
 
     /**
+     * Get time taken to complete the specified animation.
+     * @param animation_name name of the animation defined in the sdf.
+     * @param nsamples total number of samples for computing the average time.
+     * @return returns animation time.
+     */
+    double getTime(1:string animation_name, 2:i32 nsamples);
+
+    /**
+     * Get walking time.
+     * @return returns walking time
+     */
+    double getWalkingTime();
+
+    /**
+     * Get stand up plus sit down time.
+     * @return returns stand up plus sit down time
+     */
+    double getStandSitTime();
+    
+    /**
+     * Get number of steps.
+     * @return returns number of steps
+     */
+    i32 getNumSteps();
+
+    /**
      * Get the list of animations associated with the actor.
      * @return returns list of animations associated with the actor.
      */
@@ -84,6 +110,12 @@ service TugInterfaceServer
      * @return returns true / false on success / failure.
      */
     bool playFromLast(1: bool complete=false);
+
+    /**
+     * Get the torso front surface x coordinate.
+     * @return returns double defining the torso front surface x coordinate.
+     */
+    double getTorsoFront();
 
     /**
      * Get current animation being played.

--- a/app/gazebo/tug/tug-scenario.world
+++ b/app/gazebo/tug/tug-scenario.world
@@ -3,15 +3,38 @@
 
 <world name="default">
 
-    <!-- Global light source -->
-    <include>
-      <uri>model://sun</uri>
-    </include>
-
     <!-- Ground plane -->
     <include>
       <uri>model://ground_plane</uri>
     </include>
+          
+    <light name='sun' type='directional'>
+      <cast_shadows>1</cast_shadows>
+      <pose>0 0 10 0 -0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>       
+          
+    <light name='user_directional_light_0' type='directional'>
+      <pose>2.0 0.0 2.0 0 -0 0</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0.1 0.1 -0.9</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.5</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>1</cast_shadows>
+    </light>
    
     <!-- R1 -->
     <model name='SIM_CER_ROBOT'>
@@ -37,6 +60,9 @@
 
     <!-- Human model -->
     <actor name="human">
+      <plugin name="actor_collisions_plugin" filename="libActorCollisionsPlugin.so">
+        <scaling collision="LowerBack_Spine_collision" scale="12.0 20.0 5.0" pose="0.05 0 0 0 -0.2 0"/>
+      </plugin>
       <skin>
         <filename>stand.dae</filename>
       </skin>
@@ -65,16 +91,19 @@
         <trajectory id="3" type="stand_up"/>
         <trajectory id="4" type="walk"/>
         <trajectory id="5" type="sit_down"/>
+        <trajectory id="6" type="sitting"/>
       </script>
       <plugin name='tug_interface' filename='libgazebo_assistiverehab_tuginterface.so'>
         <yarpConfigurationFile>model://tugInterface.ini</yarpConfigurationFile>
       </plugin>
     </actor>
 
+
     <!-- Chair -->
     <model name='chair'>
       <include>
         <uri>model://VisitorChair</uri>
+        <!--<uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/VisitorChair</uri>-->
       </include>
       <pose>-0.50 0.0 0.0 0.0 0.0 1.57</pose>
     </model>

--- a/app/gazebo/tug/tugInterface.ini
+++ b/app/gazebo/tug/tugInterface.ini
@@ -1,8 +1,9 @@
 name                /tug_input_port
 starting_animation  "stand"
 targets             (0.0 0.0 0.0
-                     4.5 0.0 0.0
+                     4.0 0.0 0.0
+                     4.0 0.0 3.14
                      0.2 0.0 3.14
                      0.2 0.0 0.0)
 linear-velocity     1.0
-angular-velocity    360.0
+angular-velocity    120.0

--- a/modules/lineDetector/src/main.cpp
+++ b/modules/lineDetector/src/main.cpp
@@ -298,8 +298,9 @@ class Detector : public RFModule, public lineDetector_IDL
         cmd.addString(model_name);
         if (gazeboPort.write(cmd,rep))
         {
-            Property prop(rep.get(0).toString().c_str());
-            Bottle *model=prop.find(model_name).asList();
+            // Property prop(rep.get(0).toString().c_str());
+            // Bottle *model=prop.find(model_name).asList();
+            Bottle *model=rep.get(0).asList();
             if (Bottle *mod_bottle=model->find("pose_world").asList())
             {
                 if(mod_bottle->size()>=7)
@@ -416,7 +417,6 @@ class Detector : public RFModule, public lineDetector_IDL
             Bottle line;
             line.addList().read(poseProp);
             prop.put(line_tag,line.get(0));
-
             if(opc_id<0)
             {
                 cmd.addList().read(prop);
@@ -747,8 +747,8 @@ class Detector : public RFModule, public lineDetector_IDL
         cmd.addString("get_state");
         if (navPort.write(cmd,rep))
         {
-            Property robotState(rep.get(0).toString().c_str());
-            if (Bottle *loc=robotState.find("robot-location").asList())
+            Bottle *robotState=rep.get(0).asList();
+            if (Bottle *loc=robotState->find("robot-location").asList())
             {
                 yarp::sig::Vector robot_location(7,0.0);
                 robot_location[0]=loc->get(0).asDouble();
@@ -756,7 +756,7 @@ class Detector : public RFModule, public lineDetector_IDL
                 robot_location[5]=1.0;
                 robot_location[6]=(M_PI/180)*loc->get(2).asDouble();
                 navFrame=yarp::math::axis2dcm(robot_location.subVector(3,6));
-                navFrame.setSubcol(robot_location.subVector(0,2),0,3);
+                navFrame.setSubcol(robot_location.subVector(0,2),0,3);              
                 updated_nav=true;
                 return true;
             }
@@ -772,7 +772,6 @@ class Detector : public RFModule, public lineDetector_IDL
         cmd.addDouble(x);
         cmd.addDouble(y);
         cmd.addDouble(theta);
-        yDebug()<<cmd.toString();
         if (navPort.write(cmd,rep))
         {
             if (rep.get(0).asVocab()==Vocab::encode("ok"))
@@ -823,7 +822,6 @@ class Detector : public RFModule, public lineDetector_IDL
                     cmd.addDouble(pose[0]);
                     cmd.addDouble(pose[1]);
                     cmd.addDouble(theta);
-                    yDebug()<<cmd.toString();
                     if (navPort.write(cmd,rep))
                     {
                         if (rep.get(0).asVocab()==Vocab::encode("ok"))

--- a/modules/managerTUG/src/idl.thrift
+++ b/modules/managerTUG/src/idl.thrift
@@ -43,4 +43,22 @@ service managerTUG_IDL
     * @return true/false on success/failure.
     */
    bool set_target(1: double x=4.5, 2: double y=0.0, 3: double theta=0.0);
+
+   /**
+    * Get the time the user takes to complete the test.
+    * @return measured time.
+    */
+   double get_measured_time();
+
+   /**
+    * Get the success status of the test.
+    * @return passed / not_passed if the test was passed or not.
+    */
+   string get_success_status();
+
+   /**
+    * Returns true when the interaction has finished.
+    * @return true / false if the interaction has finished or not.
+    */
+   bool has_finished();
 }

--- a/modules/managerTUG/src/main.cpp
+++ b/modules/managerTUG/src/main.cpp
@@ -1083,7 +1083,6 @@ class Manager : public RFModule, public managerTUG_IDL
         cmd.addDouble(target[0]);
         cmd.addDouble(target[1]);
         cmd.addDouble(target[2]);
-        yDebug()<<cmd.toString();
         if (navigationPort.write(cmd,rep))
         {
             if (rep.get(0).asVocab()==ok)
@@ -1126,8 +1125,7 @@ class Manager : public RFModule, public managerTUG_IDL
             cmd.addString("SIM_CER_ROBOT");
             if (gazeboPort.write(cmd,rep))
             {
-                Property prop(rep.get(0).toString().c_str());
-                Bottle *model=prop.find("SIM_CER_ROBOT").asList();
+                Bottle *model=rep.get(0).asList();
                 if (Bottle *pose=model->find("pose_world").asList())
                 {
                     if(pose->size()>=7)
@@ -1963,7 +1961,7 @@ class Manager : public RFModule, public managerTUG_IDL
                     set_walking_speed(rep);
                 }
             }
-            human_state=rep.get(0).find("human-state").asString();
+            human_state=rep.find("human-state").asString();
             yInfo()<<"Human state"<<human_state;
         }
 
@@ -2198,8 +2196,8 @@ class Manager : public RFModule, public managerTUG_IDL
         cmd.addString("get_state");
         if (navigationPort.write(cmd,rep))
         {
-            Property robotState(rep.get(0).toString().c_str());
-            if (Bottle *loc=robotState.find("robot-location").asList())
+            Bottle *robotState=rep.get(0).asList();
+            if (Bottle *loc=robotState->find("robot-location").asList())
             {
                 double x=loc->get(0).asDouble();
                 double line_center=(p0[0]+p1[0])/2;
@@ -2256,7 +2254,6 @@ class Manager : public RFModule, public managerTUG_IDL
         cmd.addInt(0);
         cmd.addString("pos");
         cmd.addList().read(target);
-        yDebug()<<cmd.toString();
         if (tmpPort->write(cmd,rep))
         {
             if (rep.get(0).asBool()==true)

--- a/modules/motionAnalyzer/app/conf/tug.ini
+++ b/modules/motionAnalyzer/app/conf/tug.ini
@@ -1,6 +1,6 @@
 [general]
 type                           test
-finish-line-thresh             0.3
+finish-line-thresh             0.0
 standing-thresh                0.025
 distance                       3.0
 time-high                      10.0

--- a/modules/motionAnalyzer/include/Manager.h
+++ b/modules/motionAnalyzer/include/Manager.h
@@ -40,6 +40,7 @@ class Manager : public yarp::os::RFModule,
     yarp::os::RpcClient scalerPort;
     yarp::os::RpcClient dtwPort;
     yarp::os::RpcClient actionPort;
+    yarp::os::RpcClient navPort;
     yarp::os::BufferedPort<yarp::os::Bottle> scopePort;
 
     enum class State { idle, sitting, standing, crossed } state;

--- a/modules/motionAnalyzer/include/Metric.h
+++ b/modules/motionAnalyzer/include/Metric.h
@@ -79,7 +79,7 @@ public:
     {
         yarp::sig::Vector num;
         yarp::sig::Vector den;
-        double minv,maxv,thresh,step_window,time_window;
+        double thresh,step_window,time_window,minv,maxv;
     } step_params;
 
     Step() {;}

--- a/modules/motionAnalyzer/src/Metric.cpp
+++ b/modules/motionAnalyzer/src/Metric.cpp
@@ -42,11 +42,11 @@ Rom::Rom(const string &type, const string &name, const RomParams &params)
     this->type=type;
     this->name=name;
     this->rom_params.tag_joint=params.tag_joint;
-    this->rom_params.tag_plane=rom_params.tag_plane;
-    this->rom_params.ref_dir=rom_params.ref_dir;
-    this->rom_params.ref_joint=rom_params.ref_joint;
-    this->rom_params.minv=rom_params.minv;
-    this->rom_params.maxv=rom_params.maxv;
+    this->rom_params.tag_plane=params.tag_plane;
+    this->rom_params.ref_dir=params.ref_dir;
+    this->rom_params.ref_joint=params.ref_joint;
+    this->rom_params.minv=params.minv;
+    this->rom_params.maxv=params.maxv;
     properties.push_back("range");
 }
 

--- a/modules/motionAnalyzer/src/Processor.cpp
+++ b/modules/motionAnalyzer/src/Processor.cpp
@@ -246,15 +246,18 @@ void Step_Processor::estimate()
     {
         Vector k1=toCurrFrame(KeyPointTag::ankle_left);
         Vector k2=toCurrFrame(KeyPointTag::ankle_right);
-        Vector sag_plane=curr_skeleton.getSagittal();
-        Vector v=k1-k2;        
-        Vector v_steplen=projectOnPlane(v,sag_plane);
-        double d1=norm(v_steplen);
+        //Vector sag_plane=curr_skeleton.getSagittal();
+        //Vector v=k1-k2;        
+        //Vector v_steplen=projectOnPlane(v,sag_plane);
+        //double d1=norm(v_steplen);
+        double d1=abs(k1[1]-k2[1]);        
+        //double d1=norm(v_steplen);
 
-        Vector cor_plane=curr_skeleton.getCoronal();
-        Vector v_stepwidth=projectOnPlane(v,cor_plane);
-        double d2=norm(v_stepwidth);
-
+        //Vector cor_plane=curr_skeleton.getCoronal();
+        //Vector v_stepwidth=projectOnPlane(v,cor_plane);
+        //double d2=norm(v_stepwidth);
+        double d2=abs(k1[0]-k2[0]);
+        
         estimateSpatialParams(d1,d2);
         cadence=estimateCadence();
         speed=estimateSpeed();
@@ -307,6 +310,7 @@ void Step_Processor::estimateSpatialParams(const double &dist,const double &widt
         tlast=tdist[strikes.back()];
     }
 
+    
     steplen=0.0;
     stepwidth=0.0;
     if ( (Time::now()-tlast)<=time_window )

--- a/modules/navController/src/idl.thrift
+++ b/modules/navController/src/idl.thrift
@@ -88,4 +88,11 @@ service navController_IDL
     *         [(skeleton-tag tag) (skeleton-location (x y))].
     */
    Property get_state();
+
+   /**
+    * Set the distance to the target.
+    * @param dist distance to keep from the skeleton (meters).
+    * @return true/false on success/failure.
+    */
+   bool set_distance_target(1:double dist);
 }

--- a/modules/navController/src/main.cpp
+++ b/modules/navController/src/main.cpp
@@ -535,6 +535,13 @@ class Navigator : public RFModule, public navController_IDL {
     return publish_state();
   }
 
+  /****************************************************************/
+  bool set_distance_target(const double dist)override {
+    lock_guard<mutex> lck(mtx_update);
+    distance_target=dist;
+    return true;
+  }
+
 /****************************************************************/
 public:
 


### PR DESCRIPTION
This PR adds several features for exposing **ground truth** and **measured values** and improving the **results** of the motion analysis.
Specifically we now:
- expose the **ground truth** and **measured** time, success rate, and interaction status;
- include an **overhead light** to the tug scenario world to improve open pose results;
- compute the **number of steps** based on the feet **y coordinate**, rather than adopting the skeleton's planes which are quite noisy especially when turning;
- rely on the **hip** to check if the **finish line is crossed**, rather than on both feet.

With @AlexAntn we have developed and used these features to generate the results for Frontiers' paper.