### PR TITLE
Fix `navController` Thrift problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Assistive and Rehabilitative Robotics
 [![ZenHub](https://img.shields.io/badge/Shipping_faster_with-ZenHub-435198.svg)](https://zenhub.com)
 [![Community](https://img.shields.io/badge/Join-Robotology_Community-blue?style=plastic&logo=github)](https://github.com/robotology/community)
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/426f2502f41d4c67a064cd0a9069faac)](https://www.codacy.com/manual/pattacini/assistive-rehab?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=robotology/assistive-rehab&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/511bd2be08fc4873a2ba4854fe14882f)](https://www.codacy.com/gh/robotology/assistive-rehab/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=robotology/assistive-rehab&amp;utm_campaign=Badge_Grade)
 ![ci](https://github.com/robotology/assistive-rehab/workflows/Continuous%20Integration/badge.svg)
 ![gh-pages](https://github.com/robotology/assistive-rehab/workflows/GitHub%20Pages/badge.svg)
 

--- a/modules/managerTUG/src/main.cpp
+++ b/modules/managerTUG/src/main.cpp
@@ -1083,7 +1083,7 @@ class Manager : public RFModule, public managerTUG_IDL
         if (wait)
             cmd.addString("go_to_wait");
         else
-            cmd.addString("go_to");
+            cmd.addString("go_to_dontwait");
         cmd.addFloat64(target[0]);
         cmd.addFloat64(target[1]);
         cmd.addFloat64(target[2]);

--- a/modules/navController/src/idl.thrift
+++ b/modules/navController/src/idl.thrift
@@ -31,7 +31,7 @@ service navController_IDL
     * @param heading_rear is true to specify if the robot has to drive backward.
     * @return true/false on success/failure.
     */
-   bool go_to(1:double x, 2:double y, 3:double theta, 4:bool heading_rear = false);
+   bool go_to_dontwait(1:double x, 2:double y, 3:double theta, 4:bool heading_rear = false);
 
    /**
     * Blocking version of reach for a target location. The service returns ack only

--- a/modules/navController/src/main.cpp
+++ b/modules/navController/src/main.cpp
@@ -435,8 +435,8 @@ class Navigator : public RFModule, public navController_IDL {
   }
 
   /****************************************************************/
-  bool go_to(const double x, const double y, const double theta,
-             const bool heading_rear)override {
+  bool go_to_dontwait(const double x, const double y, const double theta,
+                      const bool heading_rear)override {
     lock_guard<mutex> lck(mtx_update);
     if (state == State::idle) {
       go_to_helper(x, y, theta, heading_rear);


### PR DESCRIPTION
This PR changes the `navController`'s command `go_to` into `go_to_dontwait`.
This is due to https://github.com/robotology/yarp/pull/2780.

Problem detected by CI in https://github.com/robotology/assistive-rehab/actions/runs/1617788410.

Also, the Codacy badge should be fixed now.