### PR TITLE
Added docker files for TUG

### DIFF
--- a/docker/compose/docker-compose-console.yml
+++ b/docker/compose/docker-compose-console.yml
@@ -1,0 +1,345 @@
+version: "3.7"
+
+x-fdg-basic: &fdg-basic
+  image: icubteamcode/fdg-basic:v2022.05.2_sources
+  environment:
+    - DISPLAY=${DISPLAY}
+    - QT_X11_NO_MITSHM=1
+    - XAUTHORITY=/root/.Xauthority
+  volumes:
+    - "/tmp/.X11-unix:/tmp/.X11-unix"
+    - "${XAUTHORITY}:/root/.Xauthority"
+    - "${HOME}/.config/yarp:/root/.config/yarp"
+    - "${HOME}/etapas-motion-results:/root/.local/share/yarp/contexts/motionAnalyzer" #for saving the results /projects/assistive-rehab/modules/motionAnalyzer/app/conf/
+  network_mode: "host"
+  privileged: true
+
+services: 
+  objectsPropertiesCollector:
+    <<: *fdg-basic
+    command: sh -c "objectsPropertiesCollector --name opc --no-load-db --no-save-db --sync-bc 0.1"
+
+  skeletonViewer:
+    <<: *fdg-basic
+    command: sh -c "skeletonViewer --x 1120 --y 10 --show-floor on --camera-viewup '(1.0 0.0 0.0)' --camera-position '(-4.0 -2.0 8.0)' --camera-focalpoint '(0.0 -2.0 0.0)'"
+
+  lineDetector:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /depthCamera/rgbImage:o; lineDetector --camera::remote /depthCamera"
+
+  skeletonRetriever:
+    <<: *fdg-basic
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        yarp wait /depthCamera/rgbImage:o
+        yarp wait /depthCamera/depthImage:o
+        yarp wait /opc/rpc
+        skeletonRetriever --depth::kernel-size 4 --depth::iterations 3 --depth::min-distance 0.5 --depth::max-distance 10.0
+
+  skeletonLocker:
+    <<: *fdg-basic
+    command: sh -c "skeletonLocker"
+        
+
+  robotSkeletonPublisher:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /cer/head/command:i; yarp wait /cer/head/rpc:i; yarp wait /cer/head/state:o; yarp wait /cer/head/stateExt:o; yarp wait /cer/torso/command:i; yarp wait /cer/torso/rpc:i; yarp wait /cer/torso/state:o; yarp wait /cer/torso/stateExt:o; yarp wait /cer/torso_tripod/command:i; yarp wait /cer/torso_tripod/rpc:i; yarp wait /cer/torso_tripod/state:o; yarp wait /cer/torso_tripod/stateExt:o; yarp wait /cer/left_arm/command:i; yarp wait /cer/left_arm/rpc:i; yarp wait /cer/left_arm/state:o; yarp wait /cer/left_arm/stateExt:o; yarp wait /cer/right_arm/command:i; yarp wait /cer/right_arm/rpc:i; yarp wait /cer/right_arm/state:o; yarp wait /cer/right_arm/stateExt:o; yarp wait /cer/left_wrist_tripod/command:i; yarp wait /cer/left_wrist_tripod/rpc:i; yarp wait /cer/left_wrist_tripod/state:o; yarp wait /cer/left_wrist_tripod/stateExt:o; yarp wait /cer/right_wrist_tripod/command:i; yarp wait /cer/right_wrist_tripod/rpc:i; yarp wait /cer/right_wrist_tripod/state:o; yarp wait /cer/right_wrist_tripod/stateExt:o; robotSkeletonPublisher --robot cer"
+
+  attentionManager:
+    <<: *fdg-basic
+    command: sh -c "attentionManager --frame world"
+
+  motionAnalyzer:
+    <<: *fdg-basic
+    command: sh -c "motionAnalyzer"
+
+  managerTUG:
+    <<: *fdg-basic
+    restart: on-failure
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        yarp wait /attentionManager/cmd:rpc
+        yarp wait /motionAnalyzer/cmd
+        yarp wait /iSpeak
+        yarp wait /iSpeak/rpc
+        yarp wait /navController/rpc
+        yarp wait /skeletonLocker/rpc
+        yarp wait /googleSpeechProcess/result:o
+        yarp wait /opc/broadcast:o
+        yarp wait /ctpservice/left_arm/rpc
+        yarp wait /ctpservice/right_arm/rpc
+        yarp wait /obstacleDetector/obstacle:o
+        managerTUG --lock false --max-timeout 30.0 --engage-azimuth "(50.0 160.0)" --starting-pose "(1.1 -2.8 120.0)"
+  
+  gazeController:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /cer/head/command:i; yarp wait /cer/head/rpc:i; yarp wait /cer/head/state:o; cer_gaze-controller --cameras::file /projects/cer/build/share/CER/contexts/cameraCalibration/cerEyes_320x240.ini"
+
+  navController:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /baseControl/rpc; yarp wait /baseControl/odometry:o; yarp wait /baseControl/control:i; navController --velocity-angular-saturation 15.0 --distance-target 2.5"
+
+  obstacleDetector:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /navController/rpc; obstacleDetector --robot cer --dist-obstacle 0.1"
+
+  ctpServiceRight:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /cer/right_arm/command:i; yarp wait /cer/right_arm/rpc:i; yarp wait /cer/right_arm/state:o; yarp wait /cer/right_arm/stateExt:o; ctpService --robot cer --part right_arm"
+
+  ctpServiceLeft:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /cer/left_arm/command:i; yarp wait /cer/left_arm/rpc:i; yarp wait /cer/left_arm/state:o; yarp wait /cer/left_arm/stateExt:o; ctpService --robot cer --part left_arm"
+
+  yarpscope:
+    <<: *fdg-basic
+    command: sh -c "yarpscope --x 1100 --y 50 --dx 800 --dy 400 --remote /motionAnalyzer/scope --bgcolor white --min -0.1 --max 0.8 --color blue --graph_size 3 --plot_title 'Step length [m]'" 
+
+  #connections
+  yconnect_0:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /iSpeak/speech-dev/rpc; yarp wait /r1/speech:rpc; yarp connect /iSpeak/speech-dev/rpc /r1/speech:rpc fast_tcp"
+
+  yconnect_1:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /iSpeak/r1:rpc; yarp wait /faceExpressionImage/rpc; yarp connect /iSpeak/r1:rpc /faceExpressionImage/rpc fast_tcp"
+
+  yconnect_2:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /faceExpressionImage/image:o; yarp wait /robot/faceDisplay/image:i; yarp connect /faceExpressionImage/image:o /robot/faceDisplay/image:i fast_tcp"
+
+  yconnect_3:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /depthCamera/rgbImage:o; yarp wait /yarpOpenPose/image:i; yarp connect /depthCamera/rgbImage:o /yarpOpenPose/image:i mjpeg"
+
+  yconnect_4:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /depthCamera/depthImage:o; yarp wait /yarpOpenPose/float:i; yarp connect /depthCamera/depthImage:o /yarpOpenPose/float:i fast_tcp+send.portmonitor+file.depthimage_compression_zlib+recv.portmonitor+file.depthimage_compression_zlib+type.dll"
+  #  command: sh -c "yarp wait /depthCamera/depthImage:o; yarp wait /yarpOpenPose/float:i; yarp connect /depthCamera/depthImage:o /yarpOpenPose/float:i fast_tcp+send.portmonitor+file.depthimage_compression_zfp+recv.portmonitor+file.depthimage_compression_zfp+type.dll"
+
+  yconnect_5:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /yarpOpenPose/float:o; yarp wait /skeletonRetriever/depth:i; yarp connect /yarpOpenPose/float:o /skeletonRetriever/depth:i fast_tcp"
+
+  yconnect_6:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /yarpOpenPose/target:o; yarp wait /skeletonRetriever/skeletons:i; yarp connect /yarpOpenPose/target:o /skeletonRetriever/skeletons:i fast_tcp"
+
+  yconnect_7:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /skeletonRetriever/opc:rpc; yarp wait /opc/rpc; yarp connect /skeletonRetriever/opc:rpc /opc/rpc fast_tcp"
+
+  yconnect_8:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /cer_gaze-controller/state:o; yarp wait /skeletonRetriever/gaze:i; yarp connect /cer_gaze-controller/state:o /skeletonRetriever/gaze:i fast_tcp"
+
+  yconnect_9:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /navController/state:o; yarp wait /skeletonRetriever/nav:i; yarp connect /navController/state:o /skeletonRetriever/nav:i fast_tcp"
+
+  yconnect_10:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /robotSkeletonPublisher/opc:rpc; yarp wait /opc/rpc; yarp connect /robotSkeletonPublisher/opc:rpc /opc/rpc fast_tcp"
+
+  yconnect_11:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /navController/state:o; yarp wait /robotSkeletonPublisher/nav:i; yarp connect /navController/state:o /robotSkeletonPublisher/nav:i fast_tcp"
+
+  yconnect_12:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /robotSkeletonPublisher/viewer:o; yarp wait /skeletonViewer:i; yarp connect /robotSkeletonPublisher/viewer:o /skeletonViewer:i fast_tcp"
+
+  yconnect_13:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /opc/broadcast:o; yarp wait /skeletonLocker/opc:i; yarp connect /opc/broadcast:o /skeletonLocker/opc:i fast_tcp"
+
+  yconnect_14:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /skeletonLocker/opc:rpc; yarp wait /opc/rpc; yarp connect /skeletonLocker/opc:rpc /opc/rpc fast_tcp"
+
+  yconnect_15:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /opc/broadcast:o; yarp wait /attentionManager/opc:i; yarp connect /opc/broadcast:o /attentionManager/opc:i fast_tcp"
+
+  yconnect_16:
+    <<: *fdg-basic
+    restart: on-failure
+    depends_on:
+      - gazeController
+    command: sh -c "yarp wait /attentionManager/gaze/cmd:rpc; yarp wait /cer_gaze-controller/rpc; yarp connect /attentionManager/gaze/cmd:rpc /cer_gaze-controller/rpc fast_tcp"
+
+  yconnect_17:
+    <<: *fdg-basic
+    restart: on-failure
+    depends_on:
+      - gazeController
+    command: sh -c "yarp wait /cer_gaze-controller/state:o; yarp wait /attentionManager/gaze/state:i; yarp connect /cer_gaze-controller/state:o /attentionManager/gaze/state:i fast_tcp"
+
+  yconnect_18:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /depthCamera/rgbImage:o; yarp wait /lineDetector/img:i; yarp connect /depthCamera/rgbImage:o /lineDetector/img:i mjpeg"
+
+  yconnect_19:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/cam:rpc; yarp wait /depthCamera/rpc:i; yarp connect /lineDetector/cam:rpc /depthCamera/rpc:i fast_tcp"
+
+  yconnect_20:
+    <<: *fdg-basic
+    restart: on-failure
+    depends_on:
+      - gazeController
+    command: sh -c "yarp wait /cer_gaze-controller/state:o; yarp wait /lineDetector/gaze/state:i; yarp connect /cer_gaze-controller/state:o /lineDetector/gaze/state:i fast_tcp"
+
+  yconnect_21:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/opc:rpc; yarp wait /opc/rpc; yarp connect /lineDetector/opc:rpc /opc/rpc fast_tcp"
+
+  yconnect_22:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/viewer:rpc; yarp wait /skeletonViewer:rpc; yarp connect /lineDetector/viewer:rpc /skeletonViewer:rpc fast_tcp"
+
+  yconnect_23:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/nav:rpc; yarp wait /navController/rpc; yarp connect /lineDetector/nav:rpc /navController/rpc fast_tcp"
+
+  yconnect_24:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/gazebo:rpc; yarp wait /tug_input_port; yarp connect /lineDetector/gazebo:rpc /tug_input_port fast_tcp"
+
+  yconnect_25:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /motionAnalyzer/opc; yarp wait /opc/rpc; yarp connect /motionAnalyzer/opc /opc/rpc fast_tcp"
+
+  yconnect_26:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /yarpOpenPose/image:o; yarp wait /viewer/skeleton; yarp connect /yarpOpenPose/image:o /viewer/skeleton mjpeg"
+
+  yconnect_27:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /opc/broadcast:o; yarp wait /navController/opc:i; yarp connect /opc/broadcast:o /navController/opc:i fast_tcp"
+
+  yconnect_28:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /skeletonLocker/viewer:o; yarp wait /skeletonViewer:i; yarp connect /skeletonLocker/viewer:o /skeletonViewer:i fast_tcp"
+
+  yconnect_29:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/attention:rpc; yarp wait /attentionManager/cmd:rpc; yarp connect /managerTUG/attention:rpc /attentionManager/cmd:rpc fast_tcp"
+
+  yconnect_30:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/analyzer:rpc; yarp wait /motionAnalyzer/cmd; yarp connect /managerTUG/analyzer:rpc /motionAnalyzer/cmd fast_tcp"
+
+  yconnect_31:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/speech:o; yarp wait /iSpeak; yarp connect /managerTUG/speech:o /iSpeak fast_tcp"
+
+  yconnect_32:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/speech:rpc; yarp wait /iSpeak/rpc; yarp connect /managerTUG/speech:rpc /iSpeak/rpc fast_tcp"
+
+  yconnect_33:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/navigation:rpc; yarp wait /navController/rpc; yarp connect /managerTUG/navigation:rpc /navController/rpc fast_tcp"
+
+  yconnect_34:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/locker:rpc; yarp wait /skeletonLocker/rpc; yarp connect /managerTUG/locker:rpc /skeletonLocker/rpc fast_tcp"
+
+  yconnect_35:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /googleSpeechProcess/result:o; yarp wait /managerTUG/answer:i; yarp connect /googleSpeechProcess/result:o /managerTUG/answer:i fast_tcp"
+
+  yconnect_36:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /opc/broadcast:o; yarp wait /managerTUG/opc:i; yarp connect /opc/broadcast:o /managerTUG/opc:i fast_tcp"
+
+  yconnect_37:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/left_arm:rpc; yarp wait /ctpservice/left_arm/rpc; yarp connect /managerTUG/left_arm:rpc /ctpservice/left_arm/rpc fast_tcp"
+
+  yconnect_38:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/right_arm:rpc; yarp wait /ctpservice/right_arm/rpc; yarp connect /managerTUG/right_arm:rpc /ctpservice/right_arm/rpc fast_tcp"
+
+  yconnect_39:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /obstacleDetector/obstacle:o; yarp wait /managerTUG/obstacle:i; yarp connect /obstacleDetector/obstacle:o /managerTUG/obstacle:i fast_tcp"
+
+  yconnect_40:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /obstacleDetector/nav:rpc; yarp wait /navController/rpc; yarp connect /obstacleDetector/nav:rpc /navController/rpc fast_tcp"
+
+  yconnect_41:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /obstacleDetector/viewer:o; yarp wait /viewer/obstacles; yarp connect /obstacleDetector/viewer:o /viewer/obstacles fast_tcp"
+
+  yconnect_42:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /depthCamera/rgbImage:o; yarp wait /viewer/raw; yarp connect /depthCamera/rgbImage:o /viewer/raw fast_tcp"
+  
+  yconnect_43:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /depthCamera/depthImage:o; yarp wait /viewer/depth; yarp connect /depthCamera/depthImage:o /viewer/depth fast_tcp+recv.portmonitor+type.dll+file.depthimage_to_mono"
+
+  yconnect_44:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /skeletonRetriever/viewer:o; yarp wait /skeletonViewer:i; yarp connect /skeletonRetriever/viewer:o /skeletonViewer:i fast_tcp"
+
+  yconnect_45:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/img:o; yarp wait /viewer/line; yarp connect /lineDetector/img:o /viewer/line mjpeg"
+
+  yconnect_46:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /motionAnalyzer/nav:cmd; yarp wait /navController/rpc; yarp connect /motionAnalyzer/nav:cmd /navController/rpc fast_tcp"
+
+  yconnect_47:
+    <<: *fdg-basic
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/trigger:rpc; yarp wait /googleSpeech/rpc; yarp connect /managerTUG/trigger:rpc /googleSpeech/rpc fast_tcp"

--- a/docker/compose/docker-compose-cuda.yml
+++ b/docker/compose/docker-compose-cuda.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+
+x-yarp-openpose: &yarp-openpose
+  image: icubteamcode/fdg-openpose:v2022.05.2_sources
+  environment:
+    - DISPLAY=${DISPLAY}
+    - QT_X11_NO_MITSHM=1
+    - XAUTHORITY=/root/.Xauthority
+  volumes:
+    - "/tmp/.X11-unix:/tmp/.X11-unix"
+    - "${XAUTHORITY}:/root/.Xauthority"
+    - "${HOME}/.config/yarp:/root/.config/yarp"  
+  network_mode: "host"
+  privileged: true
+
+services:
+  y_openpose:
+    <<: *yarp-openpose
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    command: sh -c "yarpOpenPose --model_folder /projects/openpose/models --img_resolution 320x240 --face_enable false --hand_enable false --num_scales 1"
+
+# docker run -it --network host --gpus all --mount type=bind,source=${HOME}/.config/yarp,target=/root/.config/yarp icubteamcode/fdg-openpose:v2022.05.2_sources bash

--- a/docker/compose/docker-compose-gazebo.yml
+++ b/docker/compose/docker-compose-gazebo.yml
@@ -1,0 +1,357 @@
+version: "3.7"
+x-yarp-base: &yarp-base
+  image: icubteamcode/fdg-gazebo:v2022.05.2_sources
+  environment:
+    - DISPLAY=${DISPLAY}
+    - QT_X11_NO_MITSHM=1
+    - YARP_FORWARD_LOG_ENABLE=1
+  volumes:
+    - "/tmp/.X11-unix:/tmp/.X11-unix"
+    - "${XAUTHORITY}:/root/.Xauthority"
+    - "${HOME}/.config/yarp:/root/.config/yarp"
+  network_mode: "host"
+
+services:
+  yserver:
+    <<: *yarp-base
+    command: sh -c "yarpserver"
+
+  faceExpressionImage:
+    <<: *yarp-base
+    command: sh -c "faceExpressionImage"
+    
+  objectsPropertiesCollector:
+    <<: *yarp-base
+    command: sh -c "objectsPropertiesCollector --name opc --no-load-db --no-save-db --sync-bc 0.1"
+
+  skeletonRetriever:
+    <<: *yarp-base
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        yarp wait /opc/rpc
+        skeletonRetriever --camera::fov "(54 42)" --camera::remote /SIM_CER_ROBOT/depthCamera --depth::kernel-size 3 --depth::iterations 1 --depth::min-distance 0.5 --depth::max-distance 10.0 -filter-keypoint-order 5.0
+
+  skeletonLocker:
+    <<: *yarp-base
+    command: sh -c "skeletonLocker"
+
+  robotSkeletonPublisher:
+    <<: *yarp-base
+    command: sh -c "yarp wait /SIM_CER_ROBOT/head/command:i; yarp wait /SIM_CER_ROBOT/head/rpc:i; yarp wait /SIM_CER_ROBOT/head/state:o; yarp wait /SIM_CER_ROBOT/head/stateExt:o; yarp wait /SIM_CER_ROBOT/torso/command:i; yarp wait /SIM_CER_ROBOT/torso/rpc:i; yarp wait /SIM_CER_ROBOT/torso/state:o; yarp wait /SIM_CER_ROBOT/torso/stateExt:o; yarp wait /SIM_CER_ROBOT/torso_tripod/command:i; yarp wait /SIM_CER_ROBOT/torso_tripod/rpc:i; yarp wait /SIM_CER_ROBOT/torso_tripod/state:o; yarp wait /SIM_CER_ROBOT/torso_tripod/stateExt:o; yarp wait /SIM_CER_ROBOT/left_arm/command:i; yarp wait /SIM_CER_ROBOT/left_arm/rpc:i; yarp wait /SIM_CER_ROBOT/left_arm/state:o; yarp wait /SIM_CER_ROBOT/left_arm/stateExt:o; yarp wait /SIM_CER_ROBOT/right_arm/command:i; yarp wait /SIM_CER_ROBOT/right_arm/rpc:i; yarp wait /SIM_CER_ROBOT/right_arm/state:o; yarp wait /SIM_CER_ROBOT/right_arm/stateExt:o; yarp wait /SIM_CER_ROBOT/left_wrist_tripod/command:i; yarp wait /SIM_CER_ROBOT/left_wrist_tripod/rpc:i; yarp wait /SIM_CER_ROBOT/left_wrist_tripod/state:o; yarp wait /SIM_CER_ROBOT/left_wrist_tripod/stateExt:o; yarp wait /SIM_CER_ROBOT/right_wrist_tripod/command:i; yarp wait /SIM_CER_ROBOT/right_wrist_tripod/rpc:i; yarp wait /SIM_CER_ROBOT/right_wrist_tripod/state:o; yarp wait /SIM_CER_ROBOT/right_wrist_tripod/stateExt:o; robotSkeletonPublisher --robot SIM_CER_ROBOT"
+
+  attentionManager:
+    <<: *yarp-base
+    command: sh -c "attentionManager --frame world"
+
+  baseControl:
+    <<: *yarp-base
+    command: sh -c "yarp wait /SIM_CER_ROBOT/mobile_base/command:i; yarp wait /SIM_CER_ROBOT/mobile_base/rpc:i; yarp wait /SIM_CER_ROBOT/mobile_base/state:o; yarp wait /SIM_CER_ROBOT/mobile_base/stateExt:o; baseControl --context baseControl_SIM --from baseCtrl_cer_sim.ini --GENERAL::use_ROS false --skip_robot_interface_check"
+
+  navController:
+    <<: *yarp-base
+    command: sh -c "yarp wait /baseControl/rpc; yarp wait /baseControl/odometry:o; yarp wait /baseControl/control:i; navController --velocity-angular-saturation 15.0 --distance-target 5.5 --velocity-linear-magnitude 0.6"
+
+  cer_gaze-controller:
+    <<: *yarp-base
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        yarp wait /SIM_CER_ROBOT/head/command:i;  
+        yarp wait /SIM_CER_ROBOT/head/rpc:i;
+        yarp wait /SIM_CER_ROBOT/head/state:o;
+        yarp wait /SIM_CER_ROBOT/head/stateExt:o;
+        yarp wait /SIM_CER_ROBOT/torso/command:i;
+        yarp wait /SIM_CER_ROBOT/torso/rpc:i;
+        yarp wait /SIM_CER_ROBOT/torso/state:o;
+        yarp wait /SIM_CER_ROBOT/torso/stateExt:o;
+        yarp wait /SIM_CER_ROBOT/torso_tripod/command:i;
+        yarp wait /SIM_CER_ROBOT/torso_tripod/rpc:i;
+        yarp wait /SIM_CER_ROBOT/torso_tripod/state:o;
+        yarp wait /SIM_CER_ROBOT/torso_tripod/stateExt:o;
+        cer_gaze-controller --robot SIM_CER_ROBOT --cameras::context cameraCalibration --cameras::file cerSimEyes_320x240.ini --joints-limits::pitch "(-5.0 5.0)" --joints-limits::yaw "(-10.0 10.0)"
+
+  motionAnalyzer:
+    <<: *yarp-base
+    command: sh -c "motionAnalyzer"
+
+  lineDetector:
+    <<: *yarp-base
+    command: sh -c "yarp wait /navController/rpc; lineDetector --simulation true --camera::remote /SIM_CER_ROBOT/depthCamera"
+
+  obstacleDetector:
+    <<: *yarp-base
+    command: sh -c "yarp wait /navController/rpc; obstacleDetector --robot SIM_CER_ROBOT"
+
+  managerTUG:
+    <<: *yarp-base
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        yarp wait /attentionManager/cmd:rpc
+        yarp wait /motionAnalyzer/cmd
+        yarp wait /iSpeak
+        yarp wait /iSpeak/rpc
+        yarp wait /navController/rpc
+        yarp wait /skeletonLocker/rpc
+        yarp wait /googleSpeechProcess/result:o
+        yarp wait /opc/broadcast:o
+        yarp wait /ctpservice/left_arm/rpc
+        yarp wait /ctpservice/right_arm/rpc
+        yarp wait /tug_input_port
+        yarp wait /obstacleDetector/obstacle:o
+        managerTUG --simulation true --lock false
+
+  ctpServiceRight:
+    <<: *yarp-base
+    command: sh -c "yarp wait /SIM_CER_ROBOT/right_arm/command:i; yarp wait /SIM_CER_ROBOT/right_arm/rpc:i; yarp wait /SIM_CER_ROBOT/right_arm/state:o; yarp wait /SIM_CER_ROBOT/right_arm/stateExt:o; ctpService --robot SIM_CER_ROBOT --part right_arm"
+
+  ctpServiceLeft:
+    <<: *yarp-base
+    command: sh -c "yarp wait /SIM_CER_ROBOT/left_arm/command:i; yarp wait /SIM_CER_ROBOT/left_arm/rpc:i; yarp wait /SIM_CER_ROBOT/left_arm/state:o; yarp wait /SIM_CER_ROBOT/left_arm/stateExt:o; ctpService --robot SIM_CER_ROBOT --part left_arm"
+
+  gazebo:
+    <<: *yarp-base
+    command: sh -c "gazebo tug-scenario.world --verbose"
+
+  yarpview_skeleton:
+    <<: *yarp-base
+    command: sh -c "yarpview --name /viewer/skeleton --x 100 --y 40 --w 400 --h 400 --p 50 --compact"
+
+  yarpview_obstacles:
+    <<: *yarp-base
+    command: sh -c "yarpview --name /viewer/obstacles --w 400 --h 400 --p 50 --compact"
+
+  skeletonViewer:
+    <<: *yarp-base
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        skeletonViewer --x 500 --y 10 --h 400 --show-floor on --floor-center "(0.0 -2.0 0.0)" --camera-viewup "(1.0 0.0 0.0)" --camera-position "(-4.0 -2.0 8.0)" --camera-focalpoint "(0.0 -2.0 0.0)"
+
+  yarpscope:
+    <<: *yarp-base
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        yarpscope --x 1100 --y 50 --dx 800 --dy 400 --remote /motionAnalyzer/scope --bgcolor white --min -0.1 --max 0.8 --color blue --graph_size 3 --plot_title "Step length [m]"
+
+  yconnect_0:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /iSpeak/speech-dev/rpc; yarp wait /SIM_CER_ROBOT/speech:rpc; yarp connect /iSpeak/speech-dev/rpc /SIM_CER_ROBOT/speech:rpc fast_tcp"
+
+  yconnect_1:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /iSpeak/r1:rpc; yarp wait /faceExpressionImage/rpc; yarp connect /iSpeak/r1:rpc /faceExpressionImage/rpc fast_tcp"
+
+  yconnect_2:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /faceExpressionImage/image:o; yarp wait /SIM_CER_ROBOT::SIM_CER_ROBOT::head_link::head_link_visual; yarp connect /faceExpressionImage/image:o /SIM_CER_ROBOT::SIM_CER_ROBOT::head_link::head_link_visual fast_tcp"
+
+  yconnect_3:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /SIM_CER_ROBOT/depthCamera/rgbImage:o; yarp wait /yarpOpenPose/image:i; yarp connect /SIM_CER_ROBOT/depthCamera/rgbImage:o /yarpOpenPose/image:i mjpeg"
+
+  yconnect_4:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /SIM_CER_ROBOT/depthCamera/depthImage:o; yarp wait /yarpOpenPose/float:i; yarp connect /SIM_CER_ROBOT/depthCamera/depthImage:o /yarpOpenPose/float:i fast_tcp"
+
+  yconnect_5:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /yarpOpenPose/float:o; yarp wait /skeletonRetriever/depth:i; yarp connect /yarpOpenPose/float:o /skeletonRetriever/depth:i fast_tcp"
+
+  yconnect_6:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /yarpOpenPose/target:o; yarp wait /skeletonRetriever/skeletons:i; yarp connect /yarpOpenPose/target:o /skeletonRetriever/skeletons:i fast_tcp"
+
+  yconnect_7:
+    <<: *yarp-base
+    restart: on-failure    
+    command: sh -c "yarp wait /skeletonRetriever/opc:rpc; yarp wait /opc/rpc; yarp connect /skeletonRetriever/opc:rpc /opc/rpc fast_tcp"
+
+  yconnect_8:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /cer_gaze-controller/state:o; yarp wait /skeletonRetriever/gaze:i; yarp connect /cer_gaze-controller/state:o /skeletonRetriever/gaze:i fast_tcp"
+
+  yconnect_9:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /navController/state:o; yarp wait /skeletonRetriever/nav:i; yarp connect /navController/state:o /skeletonRetriever/nav:i fast_tcp"
+
+  yconnect_10:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /robotSkeletonPublisher/opc:rpc; yarp wait /opc/rpc; yarp connect /robotSkeletonPublisher/opc:rpc /opc/rpc fast_tcp"
+
+  yconnect_11:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /navController/state:o; yarp wait /robotSkeletonPublisher/nav:i; yarp connect /navController/state:o /robotSkeletonPublisher/nav:i fast_tcp"
+
+  yconnect_12:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /robotSkeletonPublisher/viewer:o; yarp wait /skeletonViewer:i; yarp connect /robotSkeletonPublisher/viewer:o /skeletonViewer:i fast_tcp"
+
+  yconnect_13:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /opc/broadcast:o; yarp wait /skeletonLocker/opc:i; yarp connect /opc/broadcast:o /skeletonLocker/opc:i fast_tcp"
+
+  yconnect_14:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /skeletonLocker/opc:rpc; yarp wait /opc/rpc; yarp connect /skeletonLocker/opc:rpc /opc/rpc fast_tcp"
+
+  yconnect_15:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /opc/broadcast:o; yarp wait /attentionManager/opc:i; yarp connect /opc/broadcast:o /attentionManager/opc:i fast_tcp"
+
+  yconnect_16:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /attentionManager/gaze/cmd:rpc; yarp wait /cer_gaze-controller/rpc; yarp connect /attentionManager/gaze/cmd:rpc /cer_gaze-controller/rpc fast_tcp"
+
+  yconnect_17:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /cer_gaze-controller/state:o; yarp wait /attentionManager/gaze/state:i; yarp connect /cer_gaze-controller/state:o /attentionManager/gaze/state:i fast_tcp"
+
+  yconnect_18:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /SIM_CER_ROBOT/depthCamera/rgbImage:o; yarp wait /lineDetector/img:i; yarp connect /SIM_CER_ROBOT/depthCamera/rgbImage:o /lineDetector/img:i mjpeg"
+
+  yconnect_19:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/cam:rpc; yarp wait /SIM_CER_ROBOT/depthCamera/rpc:i; yarp connect /lineDetector/cam:rpc /SIM_CER_ROBOT/depthCamera/rpc:i fast_tcp"
+
+  yconnect_20:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /cer_gaze-controller/state:o; yarp wait /lineDetector/gaze/state:i; yarp connect /cer_gaze-controller/state:o /lineDetector/gaze/state:i fast_tcp"
+
+  yconnect_21:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/opc:rpc; yarp wait /opc/rpc; yarp connect /lineDetector/opc:rpc /opc/rpc fast_tcp"
+
+  yconnect_22:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/viewer:rpc; yarp wait /skeletonViewer:rpc; yarp connect /lineDetector/viewer:rpc /skeletonViewer:rpc fast_tcp"
+
+  yconnect_23:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/nav:rpc; yarp wait /navController/rpc; yarp connect /lineDetector/nav:rpc /navController/rpc fast_tcp"
+
+  yconnect_24:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /lineDetector/gazebo:rpc; yarp wait /tug_input_port; yarp connect /lineDetector/gazebo:rpc /tug_input_port fast_tcp"
+
+  yconnect_25:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /motionAnalyzer/opc; yarp wait /opc/rpc; yarp connect /motionAnalyzer/opc /opc/rpc fast_tcp"
+
+  yconnect_26:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /yarpOpenPose/image:o; yarp wait /viewer/skeleton; yarp connect /yarpOpenPose/image:o /viewer/skeleton mjpeg"
+
+  yconnect_27:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /opc/broadcast:o; yarp wait /navController/opc:i; yarp connect /opc/broadcast:o /navController/opc:i fast_tcp"
+
+  yconnect_28:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /skeletonLocker/viewer:o; yarp wait /skeletonViewer:i; yarp connect /skeletonLocker/viewer:o /skeletonViewer:i fast_tcp"
+
+  yconnect_29:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/attention:rpc; yarp wait /attentionManager/cmd:rpc; yarp connect /managerTUG/attention:rpc /attentionManager/cmd:rpc fast_tcp"
+
+  yconnect_30:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/analyzer:rpc; yarp wait /motionAnalyzer/cmd; yarp connect /managerTUG/analyzer:rpc /motionAnalyzer/cmd fast_tcp"
+
+  yconnect_31:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/speech:o; yarp wait /iSpeak; yarp connect /managerTUG/speech:o /iSpeak fast_tcp"
+
+  yconnect_32:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/speech:rpc; yarp wait /iSpeak/rpc; yarp connect /managerTUG/speech:rpc /iSpeak/rpc fast_tcp"
+
+  yconnect_33:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/navigation:rpc; yarp wait /navController/rpc; yarp connect /managerTUG/navigation:rpc /navController/rpc fast_tcp"
+
+  yconnect_34:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/locker:rpc; yarp wait /skeletonLocker/rpc; yarp connect /managerTUG/locker:rpc /skeletonLocker/rpc fast_tcp"
+
+  yconnect_35:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /googleSpeechProcess/result:o; yarp wait /managerTUG/answer:i; yarp connect /googleSpeechProcess/result:o /managerTUG/answer:i fast_tcp"
+
+  yconnect_36:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /opc/broadcast:o; yarp wait /managerTUG/opc:i; yarp connect /opc/broadcast:o /managerTUG/opc:i fast_tcp"
+
+  yconnect_37:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/left_arm:rpc; yarp wait /ctpservice/left_arm/rpc; yarp connect /managerTUG/left_arm:rpc /ctpservice/left_arm/rpc fast_tcp"
+
+  yconnect_38:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/right_arm:rpc; yarp wait /ctpservice/right_arm/rpc; yarp connect /managerTUG/right_arm:rpc /ctpservice/right_arm/rpc fast_tcp"
+
+  yconnect_39:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /managerTUG/gazebo:rpc; yarp wait /tug_input_port; yarp connect /managerTUG/gazebo:rpc /tug_input_port fast_tcp"
+
+  yconnect_40:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /obstacleDetector/obstacle:o; yarp wait /managerTUG/obstacle:i; yarp connect /obstacleDetector/obstacle:o /managerTUG/obstacle:i fast_tcp"
+
+  yconnect_41:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /obstacleDetector/nav:rpc; yarp wait /navController/rpc; yarp connect /obstacleDetector/nav:rpc /navController/rpc fast_tcp"
+
+  yconnect_42:
+    <<: *yarp-base
+    restart: on-failure
+    command: sh -c "yarp wait /obstacleDetector/viewer:o; yarp wait /viewer/obstacles; yarp connect /obstacleDetector/viewer:o /viewer/obstacles fast_tcp"

--- a/docker/compose/docker-compose-nav.yml
+++ b/docker/compose/docker-compose-nav.yml
@@ -1,0 +1,24 @@
+version: "3.7"
+
+x-fdg-navigation: &fdg-navigation
+  image: icubteamcode/fdg-navigation:v2022.05.2_sources
+  volumes:
+    - "${HOME}/.config/yarp:/root/.config/yarp"
+  network_mode: "host"
+  privileged: true
+
+services:
+
+  baseControl:
+    <<: *fdg-navigation
+    command: sh -c "yarp wait /cer/mobile_base/command:i; yarp wait /cer/mobile_base/rpc:i; yarp wait /cer/mobile_base/state:o; yarp wait /cer/mobile_base/stateExt:o; baseControl --context baseControl --from baseCtrl_cer.ini --skip_robot_interface_check"
+    
+  joystickControl:
+    <<: *fdg-navigation
+    command: sh -c "yarp wait /cer/mobile_base/command:i; yarp wait /cer/mobile_base/rpc:i; yarp wait /cer/mobile_base/state:o; cd /projects/assistive-rehab/docker/conf; joystickCtrl --from joystick_cer_linux_high_speed_stratus.ini --force_configuration --GENERAL::outputPortName /joystickCtrl:o"
+    
+  yconnect_0:
+    <<: *fdg-navigation
+    restart: on-failure
+    command: sh -c "yarp wait /joystickCtrl:o; yarp wait /baseControl/joystick1:i; yarp connect /joystickCtrl:o /baseControl/joystick1:i fast_tcp"
+

--- a/docker/compose/docker-compose-speech.yml
+++ b/docker/compose/docker-compose-speech.yml
@@ -1,0 +1,50 @@
+version: "3.7"
+x-fdg-speech: &fdg-speech
+  image: icubteamcode/fdg-speech:v2022.05.2_sources
+  environment:
+    - DISPLAY=${DISPLAY}
+    - QT_X11_NO_MITSHM=1
+    - XAUTHORITY=/root/.Xauthority
+    - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
+    - FILE_INPUT=google-key.json
+    - XDG_RUNTIME_DIR
+  volumes:
+    - "/tmp/.X11-unix:/tmp/.X11-unix"
+    - "${XAUTHORITY}:/root/.Xauthority"
+    - "${HOME}/.config/yarp:/root/.config/yarp"
+    - "${ROBOT_CODE}/assistive-rehab-private/google:/root/authorization"
+    - "${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native"
+    - "~/.config/pulse/cookie:/root/.config/pulse/cookie"
+  network_mode: "host"
+  privileged: true
+
+# docker run --rm -it --network host --device /dev/snd -e PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native -v ${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native -v ~/.config/pulse/cookie:/root/.config/pulse/cookie --group-add $(getent group audio | cut -d: -f3) --privileged --env FILE_INPUT=google-key.json --mount type=bind,source=${HOME}/teamcode/key,target=/root/authorization --mount type=bind,source=${HOME}/.config/yarp,target=/root/.config/yarp icubteamcode/fdg-speech:v2022.05.2_sources bash
+
+services:
+  node-button.js:
+    <<: *fdg-speech
+    command: sh -c "yarp wait /managerTUG/cmd:rpc; cd /projects/assistive-rehab/app/scripts; /root/.nvm/versions/node/v14.17.0/bin/node node-button.js --host 0.0.0.0 --listenPort 80"
+  
+  microphone:
+    <<: *fdg-speech
+    command: sh -c "yarpdev --device AudioRecorderWrapper --subdevice portaudioRecorder --name /microphone --min_samples_over_network 4000 --max_samples_over_network 4000"
+
+  googleSpeech:
+    <<: *fdg-speech
+    command: sh -c "googleSpeech --language_code it-IT"
+  
+  googleSpeechProcess:
+    <<: *fdg-speech
+    command: sh -c "googleSpeechProcess"
+
+  yconnect_0:
+    <<: *fdg-speech
+    command: sh -c "yarp wait /microphone/audio:o; yarp wait /googleSpeech/sound:i; yarp connect /microphone/audio:o /googleSpeech/sound:i fast_tcp"
+
+  yconnect_1:
+    <<: *fdg-speech
+    command: sh -c "yarp wait /googleSpeech/commands:rpc; yarp wait /microphone/rpc; yarp connect /googleSpeech/commands:rpc /microphone/rpc fast_tcp"
+
+  yconnect_2:
+    <<: *fdg-speech
+    command: sh -c "yarp wait /googleSpeech/result:o; yarp wait /googleSpeechProcess/text:i; yarp connect /googleSpeech/result:o /googleSpeechProcess/text:i fast_tcp"

--- a/docker/images/basic/Dockerfile
+++ b/docker/images/basic/Dockerfile
@@ -1,0 +1,125 @@
+#docker build -t icubteamcode/fdg-basic:v2022.05.2_sources .
+ARG SOURCE_IMG="ubuntu:focal"
+FROM $SOURCE_IMG as builder
+
+LABEL maintainer="valentina.vasco@iit.it, alexandre.gomespereira@iit.it, vadim.tikhanoff@iit.it" 
+
+ARG PROJECTS_DIR=/projects
+ARG CMAKE_GENERATOR="Unix Makefiles"
+ARG BUILD_TYPE=Release
+ARG CMAKE_EXTRA_OPTIONS=-j8
+# ARG INSTALL_DIR="${PROJECTS_DIR}/robotology-superbuild/build/install/share/ICUBcontrib"
+ARG INSTALL_DIR="/usr/local"
+ARG SUPERBUILD_RELEASE="v2022.05.2"
+
+# Non-interactive installation mode
+ENV DEBIAN_FRONTEND=noninteractive
+ENV QT_X11_NO_MITSHM 1
+ENV YARP_COLORED_OUTPUT=1
+
+# Dependencies
+RUN apt update && apt install -y \
+    git \
+    # motion analysis
+    libmatio-dev \
+    # depth compression
+    zlib1g \
+    # for event collection
+    libjsoncpp-dev \
+    software-properties-common \
+    wget
+
+# Install realsense and utilities
+#from https://github.com/IntelRealSense/librealsense/blob/master/doc/distribution_linux.md
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE && \
+    add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo $(lsb_release -cs) main" -u
+RUN apt install -y librealsense2-dkms librealsense2-utils librealsense2-dev
+
+# Install superbuild with its dependencies
+RUN mkdir ${PROJECTS_DIR} && cd ${PROJECTS_DIR} &&\
+    git clone https://github.com/robotology/robotology-superbuild.git &&\
+    cd robotology-superbuild &&\
+    git checkout ${SUPERBUILD_RELEASE} &&\
+    ./scripts/install_apt_dependencies.sh &&\
+    mkdir build && cd build &&\
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DNON_INTERACTIVE_BUILD:BOOL=ON \
+        -DROBOTOLOGY_ENABLE_CORE:BOOL=ON \
+        -DYCM_USE_DEPRECATED:BOOL=OFF \
+        -DROBOTOLOGY_USES_GAZEBO=OFF \
+        # enable basic demos for speech
+        -DROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS=ON \ 
+        -DYCM_EP_INSTALL_DIR=${INSTALL_DIR} \
+        &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS}  -j5
+
+# Enable depth for yarp
+RUN cd ${PROJECTS_DIR}/robotology-superbuild/src/YARP && \
+    cmake . \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DENABLE_yarpcar_mjpeg=ON \
+        -DENABLE_yarpmod_RGBDSensorWrapper=ON \
+        -DENABLE_yarpmod_RGBDSensorClient=ON \
+        -DENABLE_yarppm_bottle_compression_zlib=ON \
+        -DENABLE_yarppm_image_compression_ffmpeg=ON \
+        -DENABLE_yarppm_depthimage_compression_zlib=ON \
+        -DENABLE_yarppm_depthimage_to_mono=ON \
+        -DENABLE_yarppm_depthimage_to_rgb=ON &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} &&\
+    make install ${CMAKE_EXTRA_OPTIONS}
+    
+# Install VTK required for skeletonViewer
+RUN cd ${PROJECTS_DIR} && git clone https://github.com/Kitware/VTK.git && \
+    cd VTK && git checkout v8.2.0 && mkdir build && cd build && \
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+        && \
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} &&\
+    make install
+
+# realsense2 has been moved here from YARP 3.5
+# RUN . /${PROJECTS_DIR}/robotology-superbuild/build/install/share/robotology-superbuild/setup.sh && \
+RUN cd ${PROJECTS_DIR} && git clone https://github.com/robotology/yarp-device-realsense2.git && \
+    cd yarp-device-realsense2 && mkdir build && cd build && \
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+        -DENABLE_realsense2=ON \
+        -DENABLE_realsense2Tracking=ON \
+        -DENABLE_realsense2withIMU=ON \
+        && \
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS}
+
+# Install cer
+RUN cd ${PROJECTS_DIR} && git clone https://github.com/robotology/cer && \
+    cd cer && git checkout devel && \
+    mkdir build && cd build && \
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DENABLE_faceExpressionImage=ON && \
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} && \
+    make ${CMAKE_EXTRA_OPTIONS}
+
+# Install assistive-rehab
+RUN cd ${PROJECTS_DIR} && git clone https://github.com/robotology/assistive-rehab.git && \
+    cd assistive-rehab && \
+    mkdir build && cd build && \
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+        &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} && \
+    make install
+
+# Execute entrypoint 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+
+CMD ["bash"]
+

--- a/docker/images/basic/entrypoint.sh
+++ b/docker/images/basic/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+source /usr/local/share/robotology-superbuild/setup.sh
+
+echo "[ -r /usr/share/bash-completion/bash_completion   ] && . /usr/share/bash-completion/bash_completion" >> /root/.bashrc
+echo "source /usr/local/share/robotology-superbuild/setup.sh" >> /root/.bashrc
+
+export CER_DIR=/projects/cer/build
+export PATH=${PATH}:${CER_DIR}/bin
+export YARP_DATA_DIRS=${YARP_DATA_DIRS}:${CER_DIR}/share/CER:/projects/yarp-device-realsense2/build/share/yarp
+
+# If a CMD is passed, execute it
+exec "$@"

--- a/docker/images/gazebo/Dockerfile
+++ b/docker/images/gazebo/Dockerfile
@@ -1,0 +1,117 @@
+#docker build -t icubteamcode/fdg-gazebo:v2022.05.2_sources .
+ARG SOURCE_IMG=gazebo:libgazebo11-focal
+FROM $SOURCE_IMG as builder
+
+LABEL maintainer="valentina.vasco@iit.it, alexandre.gomespereira@iit.it, vadim.tikhanoff@iit.it" 
+
+ARG PROJECTS_DIR=/projects
+ARG CMAKE_GENERATOR="Unix Makefiles"
+ARG BUILD_TYPE=Release
+ARG CMAKE_EXTRA_OPTIONS=-j8
+ARG INSTALL_DIR="/usr/local"
+#option for superbuild
+ARG SUPERBUILD_RELEASE="v2022.05.2"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Dependencies
+RUN mkdir /etc/bash_completion.d/ && \
+    apt update && \
+    apt install -y git \
+    apt-utils \
+    bash-completion \
+    wget \
+    software-properties-common
+
+# Clone relevant repos
+RUN mkdir ${PROJECTS_DIR} && cd ${PROJECTS_DIR} &&\
+    git clone https://github.com/vvasco/gazebo.git &&\
+    git clone https://github.com/robotology/robotology-superbuild.git &&\
+    git clone https://github.com/robotology/cer.git &&\
+    git clone https://github.com/robotology/cer-sim.git &&\
+    git clone https://github.com/robotology/navigation.git &&\
+    git clone https://github.com/robotology/assistive-rehab.git
+
+# Install superbuild dependencies
+RUN cd ${PROJECTS_DIR}/robotology-superbuild &&\
+    git checkout ${SUPERBUILD_RELEASE} &&\
+    ./scripts/install_apt_dependencies.sh 
+
+# We need this gazebo fork which includes actor changes for TUG implementation
+RUN cd ${PROJECTS_DIR}/gazebo &&\
+    git checkout tug && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make install ${CMAKE_EXTRA_OPTIONS}
+
+# Build superbuild
+RUN cd ${PROJECTS_DIR}/robotology-superbuild &&\
+    mkdir build && cd build &&\
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DNON_INTERACTIVE_BUILD:BOOL=ON \
+        -DROBOTOLOGY_ENABLE_CORE:BOOL=ON \
+        -DROBOTOLOGY_USES_GAZEBO=ON \
+        -DYCM_EP_INSTALL_DIR=${INSTALL_DIR} \
+        &&\
+    cmake --build . --target update-all -- ${CMAKE_EXTRA_OPTIONS} &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS}
+
+# Build GazeboYARPPlugins to disable network wrappers
+RUN cd ${PROJECTS_DIR}/robotology-superbuild/src/GazeboYARPPlugins &&\
+    cmake . \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DGAZEBO_YARP_PLUGINS_DISABLE_IMPLICIT_NETWORK_WRAPPERS:BOOL=ON \
+        -DYCM_EP_INSTALL_DIR=${INSTALL_DIR} \
+        &&\
+   cmake --build . -- ${CMAKE_EXTRA_OPTIONS} &&\
+   make install ${CMAKE_EXTRA_OPTIONS}
+
+# Clone cer-sim
+# ref commit: f95408abcdfd2b94221203140c81bde607adcdec
+RUN cd ${PROJECTS_DIR}/cer-sim && git checkout devel
+
+# Build CER
+# ref commit: 8d794a2980d6b8def11e2c01ef5916c78f3da6f2
+RUN cd ${PROJECTS_DIR}/cer && \
+    git checkout devel &&\
+    mkdir build && cd build &&\
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DENABLE_cermod_cerDoubleLidar=ON \
+        -DENABLE_cermod_cerOdometry=ON \
+        -DENABLE_cermod_tripodMotionControl=ON \
+        -DENABLE_faceExpressionImage=ON \
+        && \
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} 
+    
+# Install navigation
+RUN cd ${PROJECTS_DIR}/navigation && git checkout 2c3834b4db013961c1dce3264e2388ed2ed6c297 &&\
+    mkdir build && cd build &&\
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+        &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} &&\
+    make install 
+
+# Install assistive-rehab
+RUN cd ${PROJECTS_DIR}/assistive-rehab && \
+    mkdir build && cd build &&\
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+        &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} &&\
+    make install
+
+# Execute entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+
+CMD ["bash"]

--- a/docker/images/gazebo/entrypoint.sh
+++ b/docker/images/gazebo/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+source /usr/local/share/robotology-superbuild/setup.sh
+
+echo "[ -r /usr/share/bash-completion/bash_completion   ] && . /usr/share/bash-completion/bash_completion" >> /root/.bashrc
+echo "source /usr/local/share/robotology-superbuild/setup.sh" >> /root/.bashrc
+
+export CER_DIR=/projects/cer/build
+export GAZEBO_RESOURCE_PATH=${GAZEBO_RESOURCE_PATH}:/usr/local/share/gazebo/worlds:/projects/assistive-rehab/app/gazebo/tug
+export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:/usr/local/share/gazebo/models:/usr/local/share/iCub/robots:/projects/cer-sim/gazebo:/projects/assistive-rehab/app/gazebo/tug
+export GAZEBO_MODEL_DATABASE_URI=http://gazebosim.org/models:https://app.gazebosim.org/fuel/models
+export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib:/usr/lib/x86_64-linux-gnu/gazebo-11/plugins:${CER_DIR}/lib:/projects/gazebo/examples/plugins/actor_collisions/build
+export PATH=${PATH}:${CER_DIR}/bin
+export YARP_DATA_DIRS=${YARP_DATA_DIRS}:${CER_DIR}/share/CER:/usr/local/share/navigation 
+
+# If a CMD is passed, execute it
+exec "$@"

--- a/docker/images/navigation/Dockerfile
+++ b/docker/images/navigation/Dockerfile
@@ -1,0 +1,34 @@
+#docker build -t icubteamcode/fdg-navigation:v2022.05.2_sources .
+ARG SOURCE_IMG="icubteamcode/fdg-basic:v2022.05.2_sources" 
+FROM $SOURCE_IMG as builder
+
+LABEL maintainer="valentina.vasco@iit.it, alexandre.gomespereira@iit.it, vadim.tikhanoff@iit.it" 
+
+ARG PROJECTS_DIR=/projects
+ARG CMAKE_GENERATOR="Unix Makefiles"
+ARG BUILD_TYPE=Release
+ARG CMAKE_EXTRA_OPTIONS=-j8
+ARG INSTALL_DIR="/usr/local"
+
+# Non-interactive installation mode
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install navigation
+#commit: before baseControl is deprecated
+RUN cd ${PROJECTS_DIR} && git clone https://github.com/robotology/navigation && \
+    cd navigation && git checkout 2c3834b4db013961c1dce3264e2388ed2ed6c297 && \
+    mkdir build && cd build && \
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+        && \
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} &&\
+    make install
+
+# Install assistive-rehab
+RUN cd ${PROJECTS_DIR}/assistive-rehab/build && \
+    make install
+
+CMD ["bash"]
+

--- a/docker/images/openpose/Dockerfile
+++ b/docker/images/openpose/Dockerfile
@@ -1,0 +1,82 @@
+#docker build -t icubteamcode/fdg-openpose:v2022.05.2_sources .
+ARG FDG_SOURCE_IMG="icubteamcode/fdg-basic:v2022.05.2_sources"
+FROM $FDG_SOURCE_IMG as builder
+
+ARG PROJECTS_DIR=/projects
+ARG CMAKE_GENERATOR="Unix Makefiles"
+ARG BUILD_TYPE=Release
+ARG CMAKE_EXTRA_OPTIONS=-j8
+ARG INSTALL_DIR="/usr/local"
+
+LABEL maintainer="valentina.vasco@iit.it, alexandre.gomespereira@iit.it, vadim.tikhanoff@iit.it" 
+
+# Non-interactive installation mode
+ENV DEBIAN_FRONTEND=noninteractive
+
+# From https://github.com/hsp-iit/tour-guide-robot/blob/ros2/docker_stuff/docker_core2/Dockerfile
+# Install CUDA and cuDNN (has to be those versions)
+# We check the keys for ubuntu 18 since cuda-10 is not available on ubuntu 20 
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin && mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+# The key for ubuntu 18 is broken
+RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub 
+RUN add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
+RUN apt update && apt install -y cuda-toolkit-10-0
+
+RUN wget https://developer.download.nvidia.com/compute/redist/cudnn/v7.6.1/Ubuntu18_04-x64/libcudnn7_7.6.1.34-1+cuda10.0_amd64.deb
+RUN dpkg -i libcudnn7_7.6.1.34-1+cuda10.0_amd64.deb
+RUN wget https://developer.download.nvidia.com/compute/redist/cudnn/v7.6.1/Ubuntu18_04-x64/libcudnn7-dev_7.6.1.34-1+cuda10.0_amd64.deb
+RUN dpkg -i libcudnn7-dev_7.6.1.34-1+cuda10.0_amd64.deb
+RUN rm libcudnn7_7.6.1.34-1+cuda10.0_amd64.deb libcudnn7-dev_7.6.1.34-1+cuda10.0_amd64.deb
+
+# GCC Compiler (because openpose requires this version)
+# Add Ubuntu 20.04 repos to install gcc-7 and remove after for safety
+RUN /bin/bash -c 'echo deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal main universe >> /etc/apt/sources.list'
+RUN apt update && sudo apt install -y gcc-7 g++-7 && sudo rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+RUN /bin/bash -c "head -n -1 /etc/apt/sources.list > /etc/apt/file.tmp; mv /etc/apt/file.tmp /etc/apt/sources.list"
+
+# Install openpose dependencies
+RUN apt update && apt install -y \
+    bzip2 \
+    libpng-dev \ 
+    libjpeg-dev \
+    libblas-dev \
+    liblapack-dev \ 
+    libsqlite3-dev \
+    libprotobuf-dev protobuf-compiler \
+    libgoogle-glog-dev \
+    libhdf5-serial-dev libhdf5-dev \
+    libatlas3-base libatlas-base-dev liblapacke-dev \
+    libleveldb-dev libsnappy-dev \
+    libboost-all-dev 
+
+# Build openpose
+RUN cd ${PROJECTS_DIR} && git clone https://github.com/CMU-Perceptual-Computing-Lab/openpose && \
+    cd openpose && git checkout tags/v1.6.0 
+    # git submodule update --init --recursive --remote && \
+
+RUN cd ${PROJECTS_DIR}/openpose && mkdir build && cd build && \
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DDOWNLOAD_HAND_MODEL=OFF \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+        &&\
+    make ${CMAKE_EXTRA_OPTIONS} && \
+    make install 
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+
+# Install yarpOpenPose   
+RUN cd ${PROJECTS_DIR} && git clone https://github.com/robotology/human-sensing && \
+    cd human-sensing/yarpOpenPose && \
+    mkdir build && cd build && \
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+        &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} &&\
+    make install
+
+CMD ["bash"]
+

--- a/docker/images/speech/Dockerfile
+++ b/docker/images/speech/Dockerfile
@@ -1,0 +1,128 @@
+#docker build -t icubteamcode/fdg-speech:v2022.05.2_sources .
+ARG SPEECH_SOURCE_IMG="icubteamcode/fdg-basic:v2022.05.2_sources"
+FROM $SPEECH_SOURCE_IMG as speech_builder
+
+ARG PROJECTS_DIR=/projects
+ARG CMAKE_GENERATOR="Unix Makefiles"
+ARG BUILD_TYPE=Release
+ARG CMAKE_EXTRA_OPTIONS=-j8
+ARG INSTALL_DIR="/usr/local"
+
+LABEL maintainer="valentina.vasco@iit.it, alexandre.gomespereira@iit.it, vadim.tikhanoff@iit.it" 
+
+# Non-interactive installation mode
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Pre-requisites before intalling grpc
+RUN apt update &&\
+    apt install -y curl gnupg \
+    autoconf \
+    libglib2.0-dev build-essential autoconf libtool pkg-config \
+    libgflags-dev \
+    golang \
+    libc-ares-dev \
+    libssl-dev \
+    # clang and LLVM C++ lib is only required for sanitizer builds
+    clang libc++-dev
+
+# Install grpc
+RUN git clone -b v1.32.0 https://github.com/grpc/grpc.git &&\
+    cd grpc &&\
+    git submodule update --init &&\
+    mkdir build &&\
+    cd build &&\
+    cmake .. -DgRPC_INSTALL=ON \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+            -DgRPC_BUILD_TESTS=OFF \
+            -DgRPC_SSL_PROVIDER=package \
+            -DgRPC_ZLIB_PROVIDER=package &&\
+    make install ${CMAKE_EXTRA_OPTIONS}
+
+# Add the Cloud SDK distribution URI as a package source
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
+RUN apt install -y apt-transport-https ca-certificates gnupg
+
+# Import the google cloud public key
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+RUN apt update &&\
+    apt install -y google-cloud-sdk
+
+# The next line updates PATH for the Google Cloud SDK.
+RUN if [ -f '/google-cloud-sdk/path.zsh.inc' ]; then . '/google-cloud-sdk/path.zsh.inc'; fi >> /root/.bashrc
+
+# The next line enables shell command completion for gcloud.
+RUN if [ -f '/google-cloud-sdk/completion.zsh.inc' ]; then . '/google-cloud-sdk/completion.zsh.inc'; fi >> /root/.bashrc
+
+# Needed for speechInteraction
+RUN git clone https://github.com/googleapis/googleapis.git &&\
+    apt install -y python-dev python3-pip \
+    python3-dev \
+    default-jdk &&\
+    cd googleapis &&\
+    sed -i '36 i FLAGS+= --experimental_allow_proto3_optional' Makefile &&\
+    make &&\
+    rm -rf /var/lib/apt/lists/*
+
+# Install node.js as we need it for the WiFi button
+# See here for the shell https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker/60137919#60137919
+SHELL ["/bin/bash", "--login", "-i", "-c"]
+ENV NVM_DIR /root/.nvm
+ENV NODE_VERSION 14.17.0 
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash 
+
+# Install yarp.js as we need it for the WiFi button
+RUN cd ${PROJECTS_DIR} && \
+    git clone https://github.com/robotology/yarp.js.git && \
+    cd yarp.js && \
+    npm install && \
+    ./node_modules/cmake-js/bin/cmake-js
+SHELL ["/bin/bash", "--login", "-c"]
+# The node-button.js script looks into this folder for yarp.js
+ENV ROBOT_CODE=/projects 
+
+#Installing sound processing related tools and audio drivers linux
+RUN apt update && apt install -y \
+       pulseaudio \
+       portaudio19-dev \
+       libportaudio2 \
+       && \
+    rm -rf /var/lib/apt/lists/* 
+
+# Install speech   
+RUN cd ${PROJECTS_DIR}/robotology-superbuild/src/speech && \
+    cmake . \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DBUILD_SVOX_SPEECH=ON \
+        -DBUILD_GOOGLE_SPEECH=ON \
+        -Dgoogleapis_INCLUDE_DIR=/googleapis/gens \
+        &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} &&\
+    make install ${CMAKE_EXTRA_OPTIONS}
+
+# Install modules for speech specific to FDG demo
+RUN cd ${PROJECTS_DIR}/assistive-rehab/modules/speechInteraction && \
+    mkdir build && cd build && \
+    cmake .. \
+        -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -Dgoogleapis_INCLUDE_DIR=/googleapis/gens \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+        &&\
+    cmake --build . -- ${CMAKE_EXTRA_OPTIONS} &&\
+    make install
+
+# Setup environment
+# ENV GOOGLE_APPLICATION_CREDENTIALS=/root/authorization/${FILE_INPUT}
+# ENV auth activate-service-account --key-file=/root/authorization/${FILE_INPUT}
+# ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/yarp
+
+# Execute entrypoint with google credentials
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+
+CMD ["bash"]
+

--- a/docker/images/speech/entrypoint.sh
+++ b/docker/images/speech/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+source /usr/local/share/robotology-superbuild/setup.sh
+
+export GOOGLE_APPLICATION_CREDENTIALS=/root/authorization/${FILE_INPUT}
+gcloud auth activate-service-account --key-file=/root/authorization/${FILE_INPUT}
+export YARP_DATA_DIRS=${YARP_DATA_DIRS}:/usr/local/share/speech
+
+# If a CMD is passed, execute it
+exec "$@"


### PR DESCRIPTION
This PR adds the docker images and the `docker-compose` files to run the TUG demo (physical and simulated).
In particular for the real robot the docker images are:
- `fdg-basic:v2022.05.2_sources`, based on [`ubuntu:focal`](https://hub.docker.com/_/ubuntu), which includes `robotology-superbuild` `v2022.05.2`, `cer`, `assistive-rehab` and its dependencies 
- `fdg-navigation:v2022.05.2_sources`, based on `fdg-basic:v2022.05.2_sources`, which includes `navigation`
- `fdg-speech:v2022.05.2_sources`, based on `fdg-basic:v2022.05.2_sources`, which includes `speech` and all the google dependencies
- `fdg-openpose:v2022.05.2_sources`, based on `fdg-basic:v2022.05.2_sources`, which includes `openpose`
- `fdg-gazebo:v2022.05.2_sources`, based on [`gazebo:libgazebo11-focal`](https://hub.docker.com/_/gazebo), which includes all the dependencies for running the TUG demo in `gazebo`

Instructions for using `docker-compose` have been updated on the website. 
Currently all the images are stored on `dockerhub` within `icubteamcode` repo.
@pattacini please notice I've also added one image specific for openpose, which can be built as follows:

`docker build -t icubteamcode/fdg-openpose:v2022.05.2_sources .`
