### PR TITLE
Improvements for TUG demo

### DIFF
--- a/app/conf/realsense2.ini
+++ b/app/conf/realsense2.ini
@@ -1,14 +1,18 @@
 device       RGBDSensorWrapper
 subdevice    realsense2
 name         /depthCamera
+rotateImage180 false
 
 [SETTINGS]
-depthResolution (424 240) # minimum resolution of the depth
-rgbResolution   (320 240)
+depthResolution (424 240)  
+rgbResolution   (320 240)	 
 framerate       30
 enableEmitter   true
+needAlignment   true
 alignmentFrame  RGB
 
 [HW_DESCRIPTION]
 clipPlanes (0.2 10.0)
 
+[QUANT_PARAM]
+depth_quant 2

--- a/app/scripts/AssistiveRehab-TUG_setup.xml.template
+++ b/app/scripts/AssistiveRehab-TUG_setup.xml.template
@@ -1,0 +1,347 @@
+<application>
+<name>Assistive Rehabilitation TUG Setup App</name>
+    <module>
+        <name>yarpdev</name>
+        <parameters>--device speech --lingware-context speech --default-language it-IT --robot r1 --pitch 80 --speed 110</parameters>
+        <node>r1-face</node>
+    </module>
+
+    <module>
+        <name>iSpeak</name>
+        <parameters>--package speech-dev</parameters>
+        <node>r1-face</node>
+    </module>
+
+    <module>
+        <name>yarpdev</name>
+        <parameters>--device faceDisplayServer</parameters>
+        <node>r1-face</node>
+    </module>
+
+    <module>
+        <name>yarpdev</name>
+        <parameters>--context AssistiveRehab --from realsense2.ini</parameters>
+        <node>r1-torso</node>
+    </module>
+
+    <module>
+        <name>faceExpressionImage</name>
+        <node>r1-face</node>
+    </module>
+
+    <module>
+        <name>yarpview</name>
+        <parameters>--name /viewer/depth --x 10 --y 40 --p 50</parameters>
+        <node>r1-console</node>
+    </module>
+
+    <module>
+        <name>yarpview</name>
+        <parameters>--name /viewer/skeleton --x 380 --y 40 --p 50</parameters>
+        <node>r1-console</node>
+    </module>
+
+    <module>
+        <name>yarpview</name>
+        <parameters>--name /viewer/line --x 770 --y 40 --p 50</parameters>
+        <node>r1-console</node>
+    </module>
+
+
+    <module>
+       <name>yarpview</name>
+       <parameters>--name /viewer/obstacles --w 400 --h 400 --p 50 --compact</parameters>
+       <node>r1-console</node>
+    </module>
+    
+    <connection>
+        <from>/joystickCtrl:o</from>
+        <to>/baseControl/joystick1:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/iSpeak/speech-dev/rpc</from>
+        <to>/r1/speech:rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/iSpeak/r1:rpc</from>
+        <to>/faceExpressionImage/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/faceExpressionImage/image:o</from>
+        <to>/robot/faceDisplay/image:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/iSpeak/speech-dev/rpc</from>
+        <to>/r1/speech:rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/iSpeak/r1:rpc</from>
+        <to>/faceExpressionImage/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/depthCamera/rgbImage:o</from>
+        <to>/yarpOpenPose/image:i</to>
+        <protocol>mjpeg</protocol>
+    </connection>
+
+    <connection>
+        <from>/depthCamera/depthImage:o</from>
+        <to>/yarpOpenPose/float:i</to>
+        <protocol>fast_tcp+send.portmonitor+file.depthimage_compression_zlib+recv.portmonitor+file.depthimage_compression_zlib+type.dll</protocol>
+        <!--<protocol>fast_tcp+send.portmonitor+file.depthimage_compression_zfp+recv.portmonitor+file.depthimage_compression_zfp+type.dll</protocol>-->
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/float:o</from>
+        <to>/skeletonRetriever/depth:i</to>
+        <protocol>fast_tcp</protocol>
+        <!--<protocol>fast_tcp+send.portmonitor+file.depthimage_compression_zfp+recv.portmonitor+file.depthimage_compression_zfp+type.dll</protocol>-->
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/target:o</from>
+        <to>/skeletonRetriever/skeletons:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/skeletonRetriever/opc:rpc</from>
+        <to>/opc/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/cer_gaze-controller/state:o</from>
+        <to>/skeletonRetriever/gaze:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/navController/state:o</from>
+        <to>/skeletonRetriever/nav:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/opc/broadcast:o</from>
+        <to>/skeletonLocker/opc:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/skeletonLocker/opc:rpc</from>
+        <to>/opc/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/opc/broadcast:o</from>
+        <to>/attentionManager/opc:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/attentionManager/gaze/cmd:rpc</from>
+        <to>/cer_gaze-controller/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/cer_gaze-controller/state:o</from>
+        <to>/attentionManager/gaze/state:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/depthCamera/rgbImage:o</from>
+        <to>/lineDetector/img:i</to>
+        <protocol>mjpeg</protocol>
+    </connection>
+
+    <connection>
+        <from>/cer_gaze-controller/state:o</from>
+        <to>/lineDetector/gaze/state:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/lineDetector/opc:rpc</from>
+        <to>/opc/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/lineDetector/nav:rpc</from>
+        <to>/navController/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/lineDetector/viewer:rpc</from>
+        <to>/skeletonViewer:rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/motionAnalyzer/opc</from>
+        <to>/opc/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/float:o</from>
+        <to>/viewer/depth</to>
+        <protocol>fast_tcp+recv.portmonitor+type.dll+file.depthimage_to_mono</protocol>
+    </connection>
+
+    <connection>
+        <from>/lineDetector/img:o</from>
+        <to>/viewer/line</to>
+        <protocol>mjpeg</protocol>
+    </connection>
+
+    <connection>
+        <from>/yarpOpenPose/image:o</from>
+        <to>/viewer/skeleton</to>
+        <protocol>mjpeg</protocol>
+    </connection>
+
+    <connection>
+        <from>/robotSkeletonPublisher/opc:rpc</from>
+        <to>/opc/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/navController/state:o</from>
+        <to>/robotSkeletonPublisher/nav:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/robotSkeletonPublisher/viewer:o</from>
+        <to>/skeletonViewer:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/skeletonLocker/viewer:o</from>
+        <to>/skeletonViewer:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/skeletonRetriever/viewer:o</from>
+        <to>/skeletonViewer:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/opc/broadcast:o</from>
+        <to>/navController/opc:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/attention:rpc</from>
+        <to>/attentionManager/cmd:rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/analyzer:rpc</from>
+        <to>/motionAnalyzer/cmd</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+    
+    <connection>
+        <from>/motionAnalyzer/nav:cmd</from>
+        <to>/navController/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/speech:o</from>
+        <to>/iSpeak</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/speech:rpc</from>
+        <to>/iSpeak/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/navigation:rpc</from>
+        <to>/navController/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/locker:rpc</from>
+        <to>/skeletonLocker/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/googleSpeechProcess/result:o</from>
+        <to>/managerTUG/answer:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/opc/broadcast:o</from>
+        <to>/managerTUG/opc:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/trigger:rpc</from>
+        <to>/googleSpeech/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/left_arm:rpc</from>
+        <to>/ctpservice/left_arm/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/managerTUG/right_arm:rpc</from>
+        <to>/ctpservice/right_arm/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/obstacleDetector/obstacle:o</from>
+        <to>/managerTUG/obstacle:i</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/obstacleDetector/nav:rpc</from>
+        <to>/navController/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+
+    <connection>
+        <from>/obstacleDetector/viewer:o</from>
+        <to>/viewer/obstacles</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
+</application>
+

--- a/modules/lineDetector/lineDetector.xml
+++ b/modules/lineDetector/lineDetector.xml
@@ -31,6 +31,7 @@
     <param default="(0.13 0.13)" desc="Vector containing the marker's length, for the start and the finish line respectively [m].">marker-size</param>
     <param default="(0.005 0.005)" desc="Vector containing the distance between markers, for the start and the finish line respectively [m].">marker-dist</param>
     <param default="false" desc="If true, lines poses are obtained directly from the gazebo world scenario.">simulation</param>
+    <param default="false" desc="If true, it uses the previously estimated pose of the line as a guess for the estimation of the current line">use-initial-guess</param>
     <param default="(54.0 42.0 160.0 120.0)" desc="Camera's intrinsics if specified from file.">camera::intrinsics</param>
     <param default="/depthCamera" desc="Camera's remote to connect to">camera::remote</param>
   </arguments>

--- a/modules/lineDetector/src/idl.thrift
+++ b/modules/lineDetector/src/idl.thrift
@@ -62,4 +62,16 @@ service lineDetector_IDL
     */
     bool go_to_line(1:string line_tag, 2:double theta);
 
+   /**
+    * Enables/Disables reuse of previous pose guess for current estimation
+    * @param flag can be true or false
+    * @return true/false on success/failure.
+    */
+    bool set_initial_guess(1:bool flag);
+
+   /**
+    * Checks if reuse of previous pose guess for current estimation is enabled
+    * @return true if usage of initial guess is enables, false otherwise.
+    */
+    bool get_initial_guess();
 }

--- a/modules/lineDetector/src/main.cpp
+++ b/modules/lineDetector/src/main.cpp
@@ -935,6 +935,7 @@ class Detector : public RFModule, public lineDetector_IDL
                 cam_distortion.at<double>(0, 3) = 0.0; //t2;
                 cam_distortion.at<double>(0, 4) = 0.0; //k3;
                 
+                rgbdDrv.close();
                 return true;
             }
         }

--- a/modules/lineDetector/src/main.cpp
+++ b/modules/lineDetector/src/main.cpp
@@ -978,7 +978,8 @@ public:
 
     /****************************************************************/
     Detector() : start_detection(false), updated_cam(false), updated_nav(false),
-        updated_odom(false), camera_configured(false), updated_line_viewer(false) { }
+        updated_odom(false), camera_configured(false), updated_line_viewer(false), 
+        lineFrame(eye(4)), camFrame(eye(4)), navFrame(eye(4)), worldFrame(eye(4))  { }
 
 };
 

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -276,6 +276,7 @@ class Retriever : public RFModule
             if (irgbd->getRgbFOV(fov_h, fov_v)) {
                 yInfo() << "camera fov_h (from sensor) =" << fov_h;
                 yInfo() << "camera fov_v (from sensor) =" << fov_v;
+                rgbdDrv.close();
                 return true;
             }
         }
@@ -1005,7 +1006,7 @@ class Retriever : public RFModule
         // remove all skeletons from OPC
         gc(numeric_limits<double>::infinity());
 
-        rgbdDrv.close();
+        // rgbdDrv.close();
         skeletonsPort.close();
         depthPort.close();
         viewerPort.close();


### PR DESCRIPTION
This PR includes the following for the TUG demo:
- the rgbd device in `skeletonRetriever` and `lineDetector` is now closed after retrieving the camera parameters to save bandwidth (otherwise they keep receiving depth images );
- depth quantization for the realsense is enabled to allow compressing depth images using `zlib`;
- the initial guess for the line pose estimate in `lineDetector` is now set to `false` by default and parameterized. This is to avoid a bad initial guess to affect detrimentally next estimates.