### PR TITLE
[eventCollector] fixed json library not found

### DIFF
--- a/modules/eventCollector/CMakeLists.txt
+++ b/modules/eventCollector/CMakeLists.txt
@@ -2,7 +2,8 @@
 # All Rights Reserved.
 # Authors: Valentina Vasco <valentina.vasco@iit.it> Alexandre Antunes <alexandre.gomespereira@iit.it>
 
-find_package(JSONCPP)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(JSONCPP jsoncpp)
 if(JSONCPP_FOUND)
     project(eventCollector)
 


### PR DESCRIPTION
This json library cannot be found through cmake, see [here](https://github.com/open-source-parsers/jsoncpp/issues/455#issuecomment-283921965). 
It can be found through `PkgConfig` (it was using this before, I removed it wrongly thinking it could find the library directly).
