### PR TITLE
Fix Assistive rehab app obstacle detector connection

### DIFF
--- a/app/scripts/AssistiveRehab-TUG.xml.template
+++ b/app/scripts/AssistiveRehab-TUG.xml.template
@@ -443,7 +443,7 @@
     <connection>
         <from>/obstacleDetector/viewer:o</from>
         <to>/viewer/obstacles</to>
-        <protocol>fast_tcp</protocol>
+        <protocol>mjpeg</protocol>
     </connection>
 
     <connection>


### PR DESCRIPTION
The connection in the app uses mjpeg compression to greatly reduce bandwidth usage.