### PR TITLE
Add changes to simplify replay of datasets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,11 @@ if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-add_subdirectory(app/gazebo/tug/plugins/tuginterface)
+option(USE_SIMULATION "Builds targets for Gazebo simulation" OFF)
+
+if(USE_SIMULATION)
+  add_subdirectory(app/gazebo/tug/plugins/tuginterface)
+endif()
 
 file(GLOB ini app/conf/*.ini)
 file(GLOB xml app/conf/*.xml)

--- a/app/scripts/AssistiveRehab-replay.xml.template
+++ b/app/scripts/AssistiveRehab-replay.xml.template
@@ -4,22 +4,24 @@
     <module>
        <name>objectsPropertiesCollector</name>
        <parameters>--name opc --no-load-db --no-save-db</parameters>
-       <node>localhost</node>
+       <node>replayer</node>
     </module>
 
     <module>
        <name>skeletonRetriever</name>
-       <parameters>--camera::fov "(54 42)"</parameters>
+       <parameters>--camera::fov "(69 42)" --depth::kernel-size 4 --depth::iterations 3 --depth::min-distance 0.5 --depth::max-distance 6.0 --filter-keypoint-order 5</parameters>
        <dependencies>
           <port timeout="5">/opc/rpc</port>
        </dependencies>
-       <node>localhost</node>
+       <node>replayer</node>
     </module>
 
+    <!--
     <module>
        <name>robotSkeletonPublisher</name>
-       <node>localhost</node>
+       <node>replayer</node>
     </module>
+    -->
 
     <module>
         <name>yarpview</name>
@@ -35,8 +37,8 @@
 
     <module>
         <name>skeletonViewer</name>
-        <parameters>--x 1120 --y 10</parameters>
-        <node>localhost</node>
+        <parameters>--x 1120 --y 10 --camera-viewup '(1.0 0.0 0.0)' --camera-position '(-4.0 -2.0 8.0)' --camera-focalpoint '(0.0 -2.0 0.0)'"</parameters>
+        <node>replayer</node>
     </module>
 
     <connection>
@@ -74,7 +76,14 @@
         <to>/skeletonViewer:i</to>
         <protocol>fast_tcp</protocol>
     </connection>
+    
+    <connection>
+        <from>/motionAnalyzer/opc</from>
+        <to>/opc/rpc</to>
+        <protocol>fast_tcp</protocol>
+    </connection>
 
+    <!--
     <connection>
         <from>/robotSkeletonPublisher/viewer:o</from>
         <to>/skeletonViewer:i</to>
@@ -86,4 +95,5 @@
         <to>/opc/rpc</to>
         <protocol>fast_tcp</protocol>
     </connection>
+    -->
 </application>

--- a/app/scripts/AssistiveRehab-replay.xml.template
+++ b/app/scripts/AssistiveRehab-replay.xml.template
@@ -96,4 +96,5 @@
         <protocol>fast_tcp</protocol>
     </connection>
     -->
+
 </application>

--- a/docker/compose/docker-compose-replay.yml
+++ b/docker/compose/docker-compose-replay.yml
@@ -27,7 +27,7 @@ services:
 
   objectsPropertiesCollector:
     <<: *fdg-basic
-    command: sh -c "objectsPropertiesCollector --name opc --no-load-db --no-save-db --sync-bc 0.1"
+    command: sh -c "objectsPropertiesCollector --name opc --no-load-db --no-save-db"
 
   dataplayer:
     <<: *fdg-basic
@@ -40,11 +40,11 @@ services:
   #     - -c
   #     - |
   #       yarp wait /opc/rpc
-  #       skeletonRetriever --depth::kernel-size 4 --depth::iterations 3 --depth::min-distance 0.5 --depth::max-distance 6.0 --filter-keypoint-order 5
+  #       skeletonRetriever --camera::fov "(69.0 42.0)" --depth::kernel-size 4 --depth::iterations 3 --depth::min-distance 0.5 --depth::max-distance 6.0 --filter-keypoint-order 5
 
-  # motionAnalyzer:
-  #   <<: *fdg-basic
-  #   command: sh -c "motionAnalyzer"
+  motionAnalyzer:
+    <<: *fdg-basic
+    command: sh -c "motionAnalyzer"
 
   skeletonViewer:
     <<: *fdg-basic
@@ -62,30 +62,30 @@ services:
 
   ## Connections
 
-  # yconnect_1:
-  #   <<: *fdg-basic
-  #   command: sh -c "yarp wait /yarpOpenPose/float:o; yarp wait /skeletonRetriever/depth:i; yarp connect /yarpOpenPose/float:o /skeletonRetriever/depth:i fast_tcp"
+  yconnect_1:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /yarpOpenPose/float:o; yarp wait /skeletonRetriever/depth:i; yarp connect /yarpOpenPose/float:o /skeletonRetriever/depth:i fast_tcp"
 
-  # yconnect_2:
-  #   <<: *fdg-basic
-  #   restart: on-failure
-  #   command: sh -c "yarp wait /yarpOpenPose/target:o; yarp wait /skeletonRetriever/skeletons:i; yarp connect /yarpOpenPose/target:o /skeletonRetriever/skeletons:i fast_tcp"
+  yconnect_2:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /yarpOpenPose/target:o; yarp wait /skeletonRetriever/skeletons:i; yarp connect /yarpOpenPose/target:o /skeletonRetriever/skeletons:i fast_tcp"
 
-  # yconnect_3:
-  #   <<: *fdg-basic
-  #   command: sh -c "yarp wait /skeletonRetriever/opc:rpc; yarp wait /opc/rpc; yarp connect /skeletonRetriever/opc:rpc /opc/rpc fast_tcp"
+  yconnect_3:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /skeletonRetriever/opc:rpc; yarp wait /opc/rpc; yarp connect /skeletonRetriever/opc:rpc /opc/rpc fast_tcp"
 
-  # yconnect_4:
-  #   <<: *fdg-basic
-  #   restart: on-failure
-  #   command: sh -c "yarp wait /yarpOpenPose/image:o; yarp wait /viewer/skeleton; yarp connect /yarpOpenPose/image:o /viewer/skeleton mjpeg"
+  yconnect_4:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /yarpOpenPose/image:o; yarp wait /viewer/skeleton; yarp connect /yarpOpenPose/image:o /viewer/skeleton mjpeg"
 
   # yconnect_5:
   #   <<: *fdg-basic
-  #   restart: on-failure
-  #   command: sh -c "yarp wait /depthCamera/depthImage:o; yarp wait /viewer/depth; yarp connect /depthCamera/depthImage:o /viewer/depth fast_tcp+recv.portmonitor+type.dll+file.depthimage_to_mono"
+  #   command: sh -c "yarp wait /depthCamera/depthImage:o; yarp wait /viewer/depth; yarp connect /depthCamera/depthImage:o /viewer/depth mjpeg+recv.portmonitor+type.dll+file.depthimage_to_mono"
 
-  # yconnect_6:
-  #   <<: *fdg-basic
-  #   restart: on-failure
-  #   command: sh -c "yarp wait /skeletonRetriever/viewer:o; yarp wait /skeletonViewer:i; yarp connect /skeletonRetriever/viewer:o /skeletonViewer:i fast_tcp"
+  yconnect_6:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /skeletonRetriever/viewer:o; yarp wait /skeletonViewer:i; yarp connect /skeletonRetriever/viewer:o /skeletonViewer:i fast_tcp"
+
+  yconnect_7:
+    <<: *fdg-basic
+    command: sh -c "yarp wait /motionAnalyzer/opc; yarp wait /opc/rpc; yarp connect /motionAnalyzer/opc /opc/rpc fast_tcp"

--- a/docker/compose/docker-compose-replay.yml
+++ b/docker/compose/docker-compose-replay.yml
@@ -1,0 +1,91 @@
+version: "3.7"
+
+x-fdg-basic: &fdg-basic
+  image: icubteamcode/fdg-basic:v2022.05.2_sources
+  environment:
+    - DISPLAY=${DISPLAY}
+    - QT_X11_NO_MITSHM=1
+    - XAUTHORITY=/root/.Xauthority
+  volumes:
+    - "/tmp/.X11-unix:/tmp/.X11-unix"
+    - "${XAUTHORITY}:/root/.Xauthority"
+    - "${HOME}/.config/yarp:/root/.config/yarp"
+    - "${HOME}/skeletonDumper:/root/skeletonDumper"
+    - "${HOME}/etapas-results/motion-analysis:/root/.local/share/yarp/contexts/motionAnalyzer" #for saving the results from motionAnalyzer
+  network_mode: "host"
+  privileged: true
+
+services: 
+
+  # yarpserver:
+  #   <<: *fdg-basic
+  #   command: sh -c "yarpserver"
+
+  yarprun:
+    <<: *fdg-basic
+    command: bash -c "yarp run --server /replayer --log"
+
+  objectsPropertiesCollector:
+    <<: *fdg-basic
+    command: sh -c "objectsPropertiesCollector --name opc --no-load-db --no-save-db --sync-bc 0.1"
+
+  dataplayer:
+    <<: *fdg-basic
+    command: bash -c "yarpdataplayer --withExtraTimeCol 0"
+
+  # skeletonRetriever:
+  #   <<: *fdg-basic
+  #   command: 
+  #     - /bin/bash
+  #     - -c
+  #     - |
+  #       yarp wait /opc/rpc
+  #       skeletonRetriever --depth::kernel-size 4 --depth::iterations 3 --depth::min-distance 0.5 --depth::max-distance 6.0 --filter-keypoint-order 5
+
+  # motionAnalyzer:
+  #   <<: *fdg-basic
+  #   command: sh -c "motionAnalyzer"
+
+  skeletonViewer:
+    <<: *fdg-basic
+    command: sh -c "skeletonViewer --x 1120 --y 10 --show-floor on --camera-viewup '(1.0 0.0 0.0)' --camera-position '(-4.0 -2.0 8.0)' --camera-focalpoint '(0.0 -2.0 0.0)'"
+
+  ###### Optional components #######
+
+  # robotSkeletonPublisher:
+  #   <<: *fdg-basic
+  #   command: sh -c "yarp wait /cer/head/command:i; yarp wait /cer/head/rpc:i; yarp wait /cer/head/state:o; yarp wait /cer/head/stateExt:o; yarp wait /cer/torso/command:i; yarp wait /cer/torso/rpc:i; yarp wait /cer/torso/state:o; yarp wait /cer/torso/stateExt:o; yarp wait /cer/torso_tripod/command:i; yarp wait /cer/torso_tripod/rpc:i; yarp wait /cer/torso_tripod/state:o; yarp wait /cer/torso_tripod/stateExt:o; yarp wait /cer/left_arm/command:i; yarp wait /cer/left_arm/rpc:i; yarp wait /cer/left_arm/state:o; yarp wait /cer/left_arm/stateExt:o; yarp wait /cer/right_arm/command:i; yarp wait /cer/right_arm/rpc:i; yarp wait /cer/right_arm/state:o; yarp wait /cer/right_arm/stateExt:o; yarp wait /cer/left_wrist_tripod/command:i; yarp wait /cer/left_wrist_tripod/rpc:i; yarp wait /cer/left_wrist_tripod/state:o; yarp wait /cer/left_wrist_tripod/stateExt:o; yarp wait /cer/right_wrist_tripod/command:i; yarp wait /cer/right_wrist_tripod/rpc:i; yarp wait /cer/right_wrist_tripod/state:o; yarp wait /cer/right_wrist_tripod/stateExt:o; robotSkeletonPublisher --robot cer"
+  
+  yarpscope:
+    <<: *fdg-basic
+    command: sh -c "yarpscope --x 1100 --y 50 --dx 800 --dy 400 --remote /motionAnalyzer/scope --bgcolor white --min -0.1 --max 0.8 --color blue --graph_size 3 --plot_title 'Step length [m]'" 
+
+  ## Connections
+
+  # yconnect_1:
+  #   <<: *fdg-basic
+  #   command: sh -c "yarp wait /yarpOpenPose/float:o; yarp wait /skeletonRetriever/depth:i; yarp connect /yarpOpenPose/float:o /skeletonRetriever/depth:i fast_tcp"
+
+  # yconnect_2:
+  #   <<: *fdg-basic
+  #   restart: on-failure
+  #   command: sh -c "yarp wait /yarpOpenPose/target:o; yarp wait /skeletonRetriever/skeletons:i; yarp connect /yarpOpenPose/target:o /skeletonRetriever/skeletons:i fast_tcp"
+
+  # yconnect_3:
+  #   <<: *fdg-basic
+  #   command: sh -c "yarp wait /skeletonRetriever/opc:rpc; yarp wait /opc/rpc; yarp connect /skeletonRetriever/opc:rpc /opc/rpc fast_tcp"
+
+  # yconnect_4:
+  #   <<: *fdg-basic
+  #   restart: on-failure
+  #   command: sh -c "yarp wait /yarpOpenPose/image:o; yarp wait /viewer/skeleton; yarp connect /yarpOpenPose/image:o /viewer/skeleton mjpeg"
+
+  # yconnect_5:
+  #   <<: *fdg-basic
+  #   restart: on-failure
+  #   command: sh -c "yarp wait /depthCamera/depthImage:o; yarp wait /viewer/depth; yarp connect /depthCamera/depthImage:o /viewer/depth fast_tcp+recv.portmonitor+type.dll+file.depthimage_to_mono"
+
+  # yconnect_6:
+  #   <<: *fdg-basic
+  #   restart: on-failure
+  #   command: sh -c "yarp wait /skeletonRetriever/viewer:o; yarp wait /skeletonViewer:i; yarp connect /skeletonRetriever/viewer:o /skeletonViewer:i fast_tcp"

--- a/modules/motionAnalyzer/src/Manager.cpp
+++ b/modules/motionAnalyzer/src/Manager.cpp
@@ -873,6 +873,14 @@ bool Manager::isSitting()
 /********************************************************/
 bool Manager::hasCrossedFinishLine()
 {
+
+    if(line_pose.size() < 1) 
+    {
+        yWarning() << "Finish line vector empty";
+        return false;
+
+    }
+
     Vector hip=skeletonIn[KeyPointTag::hip_center]->getPoint();
     // Vector foot_right=skeletonIn[KeyPointTag::ankle_right]->getPoint();
     // Vector foot_left=skeletonIn[KeyPointTag::ankle_left]->getPoint();

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -881,8 +881,8 @@ class Retriever : public RFModule
         rgbdOpts.put("DepthCarrier", "fast_tcp");
 
         if (!rgbdDrv.open(rgbdOpts)) {
-            yError() << "Unable to talk to depthCamera!";
-            yWarning() << "Retrieving camera intrinsics from command line";
+            yError() << "Unable to talk to depthCamera!";            
+            yWarning() << "Retrieving camera intrinsics from file";
         }
 
         skeletonsPort.open("/skeletonRetriever/skeletons:i");

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -862,6 +862,7 @@ class Retriever : public RFModule
                 if (!camera_configured)
                 {
                     yError() << "Unable to read camera parameters from file";
+                    return false;
                 }
             }
             if (gCamera.check("remote"))

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -880,9 +880,9 @@ class Retriever : public RFModule
         rgbdOpts.put("ImageCarrier", "mjpeg");
         rgbdOpts.put("DepthCarrier", "fast_tcp");
 
-        if (!rgbdDrv.open(rgbdOpts)) {
-            yError() << "Unable to talk to depthCamera!";            
-            yWarning() << "Retrieving camera intrinsics from file";
+        if (!rgbdDrv.open(rgbdOpts) && !camera_configured) {
+            yError() << "Unable to talk to depthCamera!";   
+            return false;        
         }
 
         skeletonsPort.open("/skeletonRetriever/skeletons:i");

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -871,32 +871,26 @@ class Retriever : public RFModule
             }
         }
 
-        Property rgbdOpts;
-        rgbdOpts.put("device", "RGBDSensorClient");
-
-        rgbdOpts.put("remoteImagePort", camera_remote + "/rgbImage:o");
-        rgbdOpts.put("remoteDepthPort", camera_remote + "/depthImage:o");
-        rgbdOpts.put("remoteRpcPort", camera_remote + "/rpc:i");
-
-        rgbdOpts.put("localImagePort", "/" + getName() + "/cam/rgb");
-        rgbdOpts.put("localDepthPort", "/" + getName() + "/cam/depth");
-        rgbdOpts.put("localRpcPort", "/" + getName() + "/cam/rpc");
-
-        rgbdOpts.put("ImageCarrier", "mjpeg");
-        rgbdOpts.put("DepthCarrier", "fast_tcp");
-
-        if (!rgbdDrv.open(rgbdOpts))
+        if (!camera_configured)
         {
-            yError() << "Unable to talk to depthCamera!";
+            Property rgbdOpts;
+            rgbdOpts.put("device", "RGBDSensorClient");
 
-            if (!camera_configured)
+            rgbdOpts.put("remoteImagePort", camera_remote + "/rgbImage:o");
+            rgbdOpts.put("remoteDepthPort", camera_remote + "/depthImage:o");
+            rgbdOpts.put("remoteRpcPort", camera_remote + "/rpc:i");
+
+            rgbdOpts.put("localImagePort", "/" + getName() + "/cam/rgb");
+            rgbdOpts.put("localDepthPort", "/" + getName() + "/cam/depth");
+            rgbdOpts.put("localRpcPort", "/" + getName() + "/cam/rpc");
+
+            rgbdOpts.put("ImageCarrier", "mjpeg");
+            rgbdOpts.put("DepthCarrier", "fast_tcp");
+
+            if (!rgbdDrv.open(rgbdOpts))
             {
-                yError() << "Unable to get depthCamera instrinsics either from device or file";
+                yError() << "Unable to talk to depthCamera!";
                 return false;
-            }
-            else
-            {
-                yInfo() << "Using depthCamera intrinsics from file";
             }
         }
 

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -882,7 +882,7 @@ class Retriever : public RFModule
 
         if (!rgbdDrv.open(rgbdOpts) && !camera_configured) {
             yError() << "Unable to talk to depthCamera!";   
-            return false;        
+            return false;
         }
 
         skeletonsPort.open("/skeletonRetriever/skeletons:i");

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -881,7 +881,7 @@ class Retriever : public RFModule
         rgbdOpts.put("DepthCarrier", "fast_tcp");
 
         if (!rgbdDrv.open(rgbdOpts) && !camera_configured) {
-            yError() << "Unable to talk to depthCamera!";   
+            yError() << "Unable to talk to depthCamera!";
             return false;
         }
 

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -859,6 +859,10 @@ class Retriever : public RFModule
                         yInfo()<<"camera fov_v (from file) ="<<fov_v;
                     }
                 }
+                if (!camera_configured)
+                {
+                    yError() << "Unable to read camera parameters from file";
+                }
             }
             if (gCamera.check("remote"))
             {
@@ -880,9 +884,19 @@ class Retriever : public RFModule
         rgbdOpts.put("ImageCarrier", "mjpeg");
         rgbdOpts.put("DepthCarrier", "fast_tcp");
 
-        if (!rgbdDrv.open(rgbdOpts) && !camera_configured) {
+        if (!rgbdDrv.open(rgbdOpts))
+        {
             yError() << "Unable to talk to depthCamera!";
-            return false;
+
+            if (!camera_configured)
+            {
+                yError() << "Unable to get depthCamera instrinsics either from device or file";
+                return false;
+            }
+            else
+            {
+                yInfo() << "Using depthCamera intrinsics from file";
+            }
         }
 
         skeletonsPort.open("/skeletonRetriever/skeletons:i");

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -488,7 +488,7 @@ class Retriever : public RFModule
                 n++;
             }
         }
-        
+
         double perc=((double)n)/((double)s->skeleton->getNumKeyPoints());
         double max_path=s->skeleton->getMaxPath();
         return ((perc>=keys_recognition_percentage) && (max_path>=min_acceptable_path));
@@ -1026,12 +1026,12 @@ class Retriever : public RFModule
     {
         // remove all skeletons from OPC
         gc(numeric_limits<double>::infinity());
-        
+
         if (rgbdDrv.isValid())
         {
             rgbdDrv.close();
         }
-        
+
         skeletonsPort.close();
         depthPort.close();
         viewerPort.close();

--- a/modules/skeletonRetriever/src/main.cpp
+++ b/modules/skeletonRetriever/src/main.cpp
@@ -882,7 +882,7 @@ class Retriever : public RFModule
 
         if (!rgbdDrv.open(rgbdOpts)) {
             yError() << "Unable to talk to depthCamera!";
-            return false;
+            yWarning() << "Retrieving camera intrinsics from command line";
         }
 
         skeletonsPort.open("/skeletonRetriever/skeletons:i");


### PR DESCRIPTION
This PR adds the following changes to improve robustness:
- Docker-compose replay to launch containers for replaying yarpopenpose dataets
- Flag in assistive-rehab to avoid compiling gazeboYarpPlugins that uses modified gazebo version
- Avoid closing skeletonRetriever if it was not possible to read camera intrinsics from device (useful when reading them from file or command line)
- Avoid segfaulting in the motionAnalyzer if there is no finish line set -> print just a warning and return false if there is no line