### PR TITLE
Fill robot location with nan in motionanalyzer if robot is offline

### DIFF
--- a/modules/motionAnalyzer/src/Manager.cpp
+++ b/modules/motionAnalyzer/src/Manager.cpp
@@ -989,6 +989,11 @@ void Manager::getSkeleton()
                                                         keyps.push_back(make_pair("robotLocation",Vector{robx,roby,robtheta}));
                                                         all_keypoints.push_back(keyps);
                                                     }
+                                                    else
+                                                    {
+                                                        keyps.push_back(make_pair("robotLocation",Vector{std::nan(""),std::nan(""),std::nan("")}));
+                                                        all_keypoints.push_back(keyps);
+                                                    }
                                                 }
                                             }
                                             if(skeletonIn[KeyPointTag::shoulder_center]->isUpdated() && curr_exercise->getName()==ExerciseTag::tug)

--- a/modules/motionAnalyzer/src/Manager.cpp
+++ b/modules/motionAnalyzer/src/Manager.cpp
@@ -989,11 +989,11 @@ void Manager::getSkeleton()
                                                         keyps.push_back(make_pair("robotLocation",Vector{robx,roby,robtheta}));
                                                         all_keypoints.push_back(keyps);
                                                     }
-                                                    else
-                                                    {
-                                                        keyps.push_back(make_pair("robotLocation",Vector{std::nan(""),std::nan(""),std::nan("")}));
-                                                        all_keypoints.push_back(keyps);
-                                                    }
+                                                }
+                                                else
+                                                {
+                                                    keyps.push_back(make_pair("robotLocation",Vector{std::nan(""),std::nan(""),std::nan("")}));
+                                                    all_keypoints.push_back(keyps);
                                                 }
                                             }
                                             if(skeletonIn[KeyPointTag::shoulder_center]->isUpdated() && curr_exercise->getName()==ExerciseTag::tug)


### PR DESCRIPTION
This PR fills the `robot-location` data structure that is collected in the .mat file with NaN values if it cannot be retrieved instead of segfaulting. 
The behaviour was tested successfully by running the `motionAnalyzer`, saving a session, and checking in MATLAB if the values were actually detected as NaN.