### PR TITLE
Use euclidean distance to estimate step distance

### DIFF
--- a/app/conf/motionAnalyzer-scope.xml
+++ b/app/conf/motionAnalyzer-scope.xml
@@ -1,35 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <portscope rows="2" columns="1" carrier="tcp" no-persistent="1">
     <plot gridx="0"
-          gridy="0"
+          gridy="1"
           minval="-0.05"
           maxval="0.8"
           bgcolor="White"
-          title="Step Raw data [m]">
+          title="Step Width [m]">
         <graph remote="/motionAnalyzer/scopeRaw"
-               index="0"
+               index="1"
                color="Red"
                size="2"
                type="lines"
-               title="Step Length raw [m]" />
-        <graph remote="/motionAnalyzer/scopeRaw"
-               index="1"
-               color="Green"
-               size="2"
-               type="lines"
-               title="Step Width raw [m]" />
+               title="Step Width [m]" />
     </plot>
-    <plot gridx="1"
+    <plot gridx="0"
        gridy="0"
        minval="-0.05"
        maxval="0.8"
        bgcolor="White"
-       title="Step Length Avg [m]">
+       title="Step Length [m]">
        <graph remote="/motionAnalyzer/scope"
                index="0"
                color="Blue"
                type="lines"
                size="2"
-               title="Step Lenght Avg [m]"/>
+               title="Step Length [m]"/>
     </plot>
 </portscope>

--- a/modules/motionAnalyzer/include/Processor.h
+++ b/modules/motionAnalyzer/include/Processor.h
@@ -102,7 +102,7 @@ public:
 
     std::pair< std::deque<double>,std::deque<int> > findPeaks(const yarp::sig::Vector &d,
                                                               const double &minv);
-    void estimateSpatialParams(const double &dist,const double &width);
+    void estimateSpatialParams(const yarp::sig::Vector &dist);
     double estimateCadence();
     double estimateSpeed();
 

--- a/modules/motionAnalyzer/src/Processor.cpp
+++ b/modules/motionAnalyzer/src/Processor.cpp
@@ -323,12 +323,12 @@ void Step_Processor::estimateSpatialParams(const Vector& dist)
     // double d1=abs(k1[1]-k2[1]);
     // double d2=abs(k1[0]-k2[0]);
 
-    Vector u1({norm(dist)}), u2({dist[1]});
+    Vector u1({norm(dist)}), u2({abs(dist[1])});
 
     // Distance between feet as norm to keep invariance
     Vector feet_euclidean_distance = filter_dist->filt(u1);
 
-    //In the skeleton frame the step width is measured along Y
+    //In the skeleton frame the step width is measured only along Y
     Vector step_width_curr_frame = filter_width->filt(u2);
 
     // Store metrics for plotting

--- a/modules/motionAnalyzer/src/Processor.cpp
+++ b/modules/motionAnalyzer/src/Processor.cpp
@@ -254,7 +254,7 @@ Step_Processor::Step_Processor(const Metric* step_)
     numsteps=0;
     steplen_raw=0.0;
     stepwidth_raw=0.0;
-    
+
     prev_steplen=0.0;
     prev_stepwidth=0.0;
     prev_cadence=0.0;
@@ -315,7 +315,8 @@ Property Step_Processor::getResult()
 /********************************************************/
 void Step_Processor::estimateSpatialParams(const Vector& dist)
 {
-    // Projection on skeleton planes needs precise pose estimation
+    // Projection on skeleton planes is commented out because
+    // it needs precise keypoints estimation
     // Vector v_steplen = projectOnPlane(dist, curr_skeleton.getSagittal());
     // Vector v_stepwidth = projectOnPlane(dist,  curr_skeleton.getCoronal());
 

--- a/modules/motionAnalyzer/src/Processor.cpp
+++ b/modules/motionAnalyzer/src/Processor.cpp
@@ -270,25 +270,14 @@ void Step_Processor::estimate()
             curr_skeleton[KeyPointTag::ankle_right]->isUpdated())
     {
         updateCurrentFrame(curr_skeleton);
-        Vector k1=toCurrFrame(KeyPointTag::ankle_left);
-        Vector k2=toCurrFrame(KeyPointTag::ankle_right);
+        Vector k1 = toCurrFrame(KeyPointTag::ankle_left);
+        Vector k2 = toCurrFrame(KeyPointTag::ankle_right);
 
-        Vector v=k1-k2;
+        Vector ankles_diff = k1 - k2;
 
-        Vector sag_plane=curr_skeleton.getSagittal();
-        Vector v_steplen=projectOnPlane(v,sag_plane);
-        double d1=norm(v_steplen);
-
-        Vector cor_plane=curr_skeleton.getCoronal();
-        Vector v_stepwidth=projectOnPlane(v,cor_plane);
-        double d2=norm(v_stepwidth);
-
-        // double d1=abs(k1[1]-k2[1]);
-        // double d2=abs(k1[0]-k2[0]);
-
-        estimateSpatialParams(d1,d2);
-        cadence=estimateCadence();
-        speed=estimateSpeed();
+        estimateSpatialParams(ankles_diff);
+        cadence = estimateCadence();
+        speed = estimateSpeed();
 
         prev_steplen=steplen;
         prev_stepwidth=stepwidth;
@@ -324,42 +313,48 @@ Property Step_Processor::getResult()
 }
 
 /********************************************************/
-void Step_Processor::estimateSpatialParams(const double &dist,const double &width)
+void Step_Processor::estimateSpatialParams(const Vector& dist)
 {
-    Vector u1({dist}),u2({width});
-    Vector output1=filter_dist->filt(u1);
-    Vector output2=filter_width->filt(u2);
-    feetdist.push_back(output1[0]);
-    feetwidth.push_back(output2[0]);
+    // Projection on skeleton planes needs precise pose estimation
+    // Vector v_steplen = projectOnPlane(dist, curr_skeleton.getSagittal());
+    // Vector v_stepwidth = projectOnPlane(dist,  curr_skeleton.getCoronal());
+
+    // double d1=abs(k1[1]-k2[1]);
+    // double d2=abs(k1[0]-k2[0]);
+
+    Vector u1({norm(dist)}), u2({dist[1]});
+
+    // Distance between feet as norm to keep invariance
+    Vector feet_euclidean_distance = filter_dist->filt(u1);
+
+    //In the skeleton frame the step width is measured along Y
+    Vector step_width_curr_frame = filter_width->filt(u2);
+
+    // Store metrics for plotting
+    steplen = steplen_raw = feet_euclidean_distance[0];
+    stepwidth = stepwidth_raw = step_width_curr_frame[0];
+
+    feetdist.push_back(steplen);
+    feetwidth.push_back(stepwidth);
+
     tdist.push_back(Time::now());
 
     pair<deque<double>,deque<int>> step_params;
+
     double tlast=0.0;
     step_params=findPeaks(feetdist,step_thresh);
     deque<double> stepvec=step_params.first;
     deque<int> strikes=step_params.second;
+
     if (strikes.size()>0)
     {
         tlast=tdist[strikes.back()];
     }
 
-    steplen_raw = output1[0];
-    stepwidth_raw = output2[0];
-    steplen=0.0;
-    stepwidth=0.0;
-    if ((Time::now()-tlast)<=time_window)
+    if ((Time::now() - tlast) <= time_window)
     {
-        for(int i=0;i<stepvec.size();i++)
-        {
-            steplen+=stepvec[i];
-        }
-        if (stepvec.size()>0)
-        {
-            steplen/=stepvec.size();
-        }
-        int laststrike=stepvec.size()>numsteps ? strikes.back() : 0;
-        stepwidth=feetwidth[laststrike];
-        numsteps=(int)strikes.size();
+        int laststrike = stepvec.size()>numsteps ? strikes.back() : 0;
+        numsteps = (int)strikes.size();
     }
 }
 

--- a/modules/skeletonRetriever/app/conf/config.ini
+++ b/modules/skeletonRetriever/app/conf/config.ini
@@ -4,10 +4,10 @@ period 0.05
 [skeleton]
 keys-recognition-confidence 0.3
 keys-recognition-percentage 0.3
-keys-acceptable-misses      5
+keys-acceptable-misses      10
 min-acceptable-path         0.5
 tracking-threshold          50
-time-to-live                1.0
+time-to-live                3.0
 
 [depth]
 enable                      false


### PR DESCRIPTION
This PR changes the evaluation of the step distance in the TUG demo to a simple computation of the euclidean distance between the ankles, instead of relying on the projection on the skeleton planes. This is because the projection can be considered reliable only with very accurate keypoints pose estimation. The distance is instead more robust