### PR TITLE
Update CI to `vtk-9.2.2` and `opecv-4.6.0`+ replaced deprecated `cv::aruco::drawAxis()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} --target install
         # vtk
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/Kitware/VTK.git --depth 1 --branch v9.0.1
+        git clone https://github.com/Kitware/VTK.git --depth 1 --branch v9.2.2
         cd VTK && mkdir -p build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         cmake --build . --config ${{ matrix.build_type }} --target install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,8 @@ jobs:
       run: |
         # opencv
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/opencv/opencv.git --depth 1 --branch 4.2.0
-        git clone https://github.com/opencv/opencv_contrib.git --depth 1 --branch 4.2.0
+        git clone https://github.com/opencv/opencv.git --depth 1 --branch 4.6.0
+        git clone https://github.com/opencv/opencv_contrib.git --depth 1 --branch 4.6.0
         cd opencv && mkdir -p build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DOPENCV_EXTRA_MODULES_PATH=${GITHUB_WORKSPACE}/opencv_contrib/modules \
               -DBUILD_EXAMPLES=OFF -DBUILD_DOCS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         sudo apt update
         sudo apt install -y git build-essential pkg-config zip unzip zlib1g-dev cmake libace-dev coinor-libipopt-dev libeigen3-dev swig \
                             qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libtinyxml-dev libgsl-dev libmatio-dev fftw3 wget curl autoconf \
-                            autogen automake libtool mlocate python3 python3-numpy python3-dev python3-pip python3-wheel
+                            autogen automake libtool mlocate python3 python3-numpy python3-dev python3-pip python3-wheel libglvnd-dev
         # install Bazel 0.26.1 needed by tensorflow_cc
         #wget https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel_0.26.1-linux-x86_64.deb
         #sudo dpkg -i bazel_0.26.1-linux-x86_64.deb

--- a/modules/lineDetector/src/main.cpp
+++ b/modules/lineDetector/src/main.cpp
@@ -19,6 +19,7 @@
 
 #include <opencv2/opencv.hpp>
 #include <opencv2/aruco.hpp>
+#include <opencv2/calib3d.hpp>
 
 #include "src/lineDetector_IDL.h"
 
@@ -715,8 +716,8 @@ class Detector : public RFModule, public lineDetector_IDL
             if (valid>0)
             {
                 yInfo()<<"n. of valid markers:"<<valid;
-                cv::aruco::drawAxis(inImgMat,cam_intrinsic,cam_distortion,rvec_v[line_idx],tvec_v[line_idx],0.5);
-                 cv::Mat Rmat;
+                cv::drawFrameAxes(inImgMat,cam_intrinsic,cam_distortion,rvec_v[line_idx],tvec_v[line_idx],0.5);
+                cv::Mat Rmat;
                 cv::Rodrigues(rvec_v[line_idx],Rmat);
                 yarp::sig::Matrix R=toYarpMat(Rmat);
                 yarp::sig::Vector pose({tvec_v[line_idx][0],tvec_v[line_idx][1],tvec_v[line_idx][2],1.0});


### PR DESCRIPTION
[CI is failing on Ubuntu](https://github.com/robotology/assistive-rehab/actions/runs/3653894614/jobs/6173816174) because of:

```console
In file included from /home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkGenericDataArray.h:72,
                 from /home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkGenericDataArray.cxx:25:
/home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkGenericDataArrayLookupHelper.h: In function ‘bool detail::isnan(T)’:
/home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkGenericDataArrayLookupHelper.h:52:26: error: ‘numeric_limits’ is not a member of ‘std’
   52 |   return has_NaN<T, std::numeric_limits<T>::has_quiet_NaN>::isnan(x);
      |                          ^~~~~~~~~~~~~~
/home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkGenericDataArrayLookupHelper.h:52:26: error: ‘numeric_limits’ is not a member of ‘std’
/home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkGenericDataArrayLookupHelper.h:52:42: error: template argument 2 is invalid
   52 |   return has_NaN<T, std::numeric_limits<T>::has_quiet_NaN>::isnan(x);
      |                                          ^
In file included from /home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkGenericDataArray.cxx:27:
/home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkDataArrayPrivate.txx: In function ‘bool vtkDataArrayPrivate::detail::isinf(T)’:
/home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkDataArrayPrivate.txx:97:31: error: ‘numeric_limits’ is not a member of ‘std’
   97 |   return has_infinity<T, std::numeric_limits<T>::has_infinity>::isinf(x);
      |                               ^~~~~~~~~~~~~~
/home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkDataArrayPrivate.txx:97:31: error: ‘numeric_limits’ is not a member of ‘std’
/home/runner/work/assistive-rehab/assistive-rehab/VTK/Common/Core/vtkDataArrayPrivate.txx:97:47: error: template argument 2 is invalid
   97 |   return has_infinity<T, std::numeric_limits<T>::has_infinity>::isinf(x);
```

Let's try out the latest VTK stable release v9.2.2.