### PR TITLE
Fix `eventCollector` file path and increase `obstacleDetector` minimum distance

### DIFF
--- a/app/scripts/AssistiveRehab-TUG_setup.xml
+++ b/app/scripts/AssistiveRehab-TUG_setup.xml
@@ -25,7 +25,7 @@
     </module>
 
     <module>
-        <name>yarpdev</name>
+        <name>yarprobotinterface</name>
         <parameters>--context AssistiveRehab --from realsense2_640x480.ini</parameters>
         <node>r1-torso</node>
     </module>

--- a/app/scripts/AssistiveRehab-TUG_setup.xml.template
+++ b/app/scripts/AssistiveRehab-TUG_setup.xml.template
@@ -25,7 +25,7 @@
     </module>
 
     <module>
-        <name>yarpdev</name>
+        <name>yarprobotinterface</name>
         <parameters>--context AssistiveRehab --from realsense2_640x480.ini</parameters>
         <node>r1-torso</node>
     </module>

--- a/docker/compose/docker-compose-console.yml
+++ b/docker/compose/docker-compose-console.yml
@@ -90,7 +90,7 @@ services:
 
   obstacleDetector:
     <<: *fdg-basic
-    command: sh -c "yarp wait /navController/rpc; obstacleDetector --robot cer --dist-obstacle 0.1"
+    command: sh -c "yarp wait /navController/rpc; obstacleDetector --robot cer --dist-obstacle 0.5"
 
   ctpServiceRight:
     <<: *fdg-basic

--- a/modules/eventCollector/src/collector.cpp
+++ b/modules/eventCollector/src/collector.cpp
@@ -234,9 +234,12 @@ public:
         // we had the trial instance to the trial list when we stop a trial
         jsonRoot["Trial"].append(jsonTrialInstance);
 
-        outputFileName = outfolder + "collected_events_user" + skeletonTag + ".json";
+        outputFileName = outfolder + "/collected_events_user" + skeletonTag + ".json";
+        yInfo() << "Saving events in" << outputFileName;
         std::ofstream output_doc(outputFileName.c_str(), std::ofstream::binary);
         output_doc << jsonRoot;
+
+        jsonRoot["Trial"] = {}; 
 
         return true;
 


### PR DESCRIPTION
This PR is just a bugfix, it fixes the:
- wrong path in the eventCollector that would cause failure in saving the events file
-  the minimum obstacle detection distance to 50cm. 10cm was way too little.
- the camera is launched with yarprobotinterface since the config file now has changed: it uses the key `config <filename.ini>`