### PR TITLE
[CI] use `iwr` and `gh` for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,16 @@ jobs:
     # ============
     - name: Download Vcpkg Prebuilt Dependencies [Windows]
       if: matrix.os == 'windows-latest'
-      shell: bash
+      shell: pwsh
       run: |
-        choco install -y curl wget
-        latest_tag=$(curl --silent https://api.github.com/repos/robotology/robotology-superbuild-dependencies-vcpkg/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-        echo "Installing robotology-superbuild-dependencies-vcpkg@${latest_tag}"
-        cd C:/
-        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/${latest_tag}/vcpkg-robotology.zip
-        7z x vcpkg-robotology.zip -oC:/
-        echo "VCPKG_INSTALLATION_ROOT=C:/robotology/vcpkg" >> ${GITHUB_ENV}
+        $response = gh api --paginate -H "Accept: application/vnd.github.v3+json" /repos/robotology/robotology-superbuild-dependencies-vcpkg/releases/latest
+        $latest_tag = ($response | ConvertFrom-Json).tag_name
+        echo "Installing robotology-superbuild-dependencies-vcpkg@$latest_tag"
+        iwr -Uri https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/$latest_tag/vcpkg-robotology.zip -OutFile C:/vcpkg-robotology.zip
+        7z x C:/vcpkg-robotology.zip -oC:/
+        "VCPKG_INSTALLATION_ROOT=C:/robotology/vcpkg" >> $env:GITHUB_ENV
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}         
         
     - name: Build Vcpkg Dependencies [Windows]
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
This PR mirrors https://github.com/robotology/icub-main/pull/849 and aims to:
- get rid of `choco` package manager outright as it's been breaking CI's lately 
- solve the rate limiter problem by using `gh`