### PR TITLE
Add configuration for 8bitdo joystick to use as trigger

### DIFF
--- a/app/conf/joystick_trigger_8bitdo.ini
+++ b/app/conf/joystick_trigger_8bitdo.ini
@@ -1,0 +1,35 @@
+
+[GENERAL]
+rateThread              1
+DefaultJoystickNumber   0
+outputPortName         /speech/trigger:o
+
+[INPUTS]
+InputsNumber    4
+Reverse         0       0       0       0
+Gain            +1.0     1.0    +0.5    +1.0
+InputMax        +32000  +32000  +32000  +32000
+InputMin        -32000  -32000  -32000  -32000
+OutputMax       -100    -100    -100    -100
+OutputMin       +100    +100    +100    +100
+Deadband        6000    6000    6000    6000
+
+[OUTPUTS]
+OutputsNumber       1
+Ax0 cartesian_xyz   0
+
+//Important:  you can execute only one-word commands or scripts
+[BUTTONS_EXECUTE]
+button5   /home/r1-user/assistive-rehab/app/scripts/speech_trigger.sh
+
+// **** Buttons ****
+// button0 A
+// button1 B
+// button2
+// button3 X
+// button4 Y
+// button5
+// button6 L1
+// button7 R1
+// button11 play
+// button12

--- a/app/scripts/speech_trigger.sh
+++ b/app/scripts/speech_trigger.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "trigger" | yarp write ... /managerTUG/cmd:rpc


### PR DESCRIPTION
This PR adds the necessary files to use the 8bitDo joystick as a speech trigger for the TUG demo. Related issue: https://github.com/robotology/assistive-rehab/issues/331

The device can be easily paired with a Ubuntu machine through the GUI.
Pairing through the command line needs the following terminal commands:
```
$ bluetoothctl
```
Now type `devices` to list the available devices to be paired. The joystick will show up as either 8bitDo or Pro Controller as name, but the mac address should be the same.
```
Device <MAC Address> 8BitDo
```
Then run the commands
```
# pair <MAC address>
# trust <MAC address>
```

and it's done.