### PR TITLE
Fix assignment of mat struct fields in `motionAnalyzer`

### DIFF
--- a/modules/motionAnalyzer/src/Manager.cpp
+++ b/modules/motionAnalyzer/src/Manager.cpp
@@ -1298,7 +1298,7 @@ bool Manager::writeStructToMat(const string& name, const Exercise* ex, mat_t *ma
 void Manager::createSubfield(matvar_t *submatvar, double *val, size_t *dims, const char *name)
 {
     matvar_t *subfield;
-    subfield=Mat_VarCreate(NULL,MAT_C_DOUBLE,MAT_T_DOUBLE,2,dims,&val,MAT_F_DONT_COPY_DATA);
+    subfield=Mat_VarCreate(NULL,MAT_C_DOUBLE,MAT_T_DOUBLE,2,dims,val,MAT_F_DONT_COPY_DATA);
     Mat_VarSetStructFieldByName(submatvar,name,0,subfield);
 }
 


### PR DESCRIPTION
This PR fixes a tiny but important bug regarding pointers that arises when saving the .mat struct that contains the information regarding TUG exercise. 
See below the parameters `tend tstart min max ...`

## **Before:**

![garbage](https://user-images.githubusercontent.com/38140169/213198057-5c2d47fd-e0f1-4ba1-9225-da0ac6fcd9e0.png)

## **After:**

![noice](https://user-images.githubusercontent.com/38140169/213198200-0dbfc769-49b3-4da3-92b6-ac9d81029d3f.png)
